### PR TITLE
ci(release): PR-based release flow compatible with main ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,18 +35,26 @@ jobs:
   open-release-pr:
     name: Open release PR
     runs-on: ubuntu-latest
-    # `workflow_dispatch` can be fired from the UI against any ref.
-    # Releases always cut from main; refuse to run if dispatched
-    # from a feature branch so an operator can't accidentally
-    # produce a release PR rooted at a work-in-progress commit.
-    if: github.ref == 'refs/heads/main'
 
     steps:
+      - name: Refuse dispatch from non-main refs
+        # `workflow_dispatch` can be fired from the UI against any
+        # ref. We want the run to show as FAILED with a clear
+        # error when an operator accidentally picks a feature
+        # branch, not skipped/green the way a job-level `if` would
+        # render. Releases always cut from main.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Release workflow must be dispatched from main; got ${{ github.ref }}."
+          echo "::error::Switch the branch selector in the Actions UI to \`main\` and retry."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
-          # Defensive double-belt: even if the `if` above somehow
-          # lets a non-main dispatch through, explicitly check out
-          # main so the bump commit is always parented to it.
+          # Defensive double-belt: even if the dispatch came from
+          # a non-main ref and the early step above is somehow
+          # bypassed, explicitly check out main so the bump commit
+          # is always parented to it.
           ref: main
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,12 @@ jobs:
           # Read current to detect no-op bumps (shouldn't happen with
           # npm version <bump>, but bail loudly if it does).
           BEFORE=$(node -p "require('./package.json').version")
-          npm version ${{ inputs.bump }} --no-git-tag-version
+          # --ignore-scripts: npm version runs preversion/version/
+          # postversion lifecycle scripts by default. None are defined
+          # today, but a future addition (or a transitive one via a
+          # config change) would silently run in CI with write access
+          # to the repo. Keep the bump bounded to version files only.
+          npm version ${{ inputs.bump }} --no-git-tag-version --ignore-scripts
           AFTER=$(node -p "require('./package.json').version")
           if [ "$BEFORE" = "$AFTER" ]; then
             echo "::error::npm version produced no change ($BEFORE == $AFTER)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,25 @@ jobs:
   open-release-pr:
     name: Open release PR
     runs-on: ubuntu-latest
+    # `workflow_dispatch` can be fired from the UI against any ref.
+    # Releases always cut from main; refuse to run if dispatched
+    # from a feature branch so an operator can't accidentally
+    # produce a release PR rooted at a work-in-progress commit.
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4
         with:
+          # Defensive double-belt: even if the `if` above somehow
+          # lets a non-main dispatch through, explicitly check out
+          # main so the bump commit is always parented to it.
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release
 
+# Opens a release PR that bumps package.json (and package-lock.json
+# if present) to the next semver. The PR goes through the standard
+# branch-protection gates (Copilot review, code scanning, CODEOWNERS
+# approval, thread resolution) exactly like any other change — the
+# bot does not push directly to main. Once the PR merges, a separate
+# `tag-on-main.yml` workflow creates the matching `v<version>` tag,
+# which in turn fires `publish.yml`.
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,10 +22,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    name: Bump version & tag
+  open-release-pr:
+    name: Open release PR
     runs-on: ubuntu-latest
 
     steps:
@@ -34,14 +43,57 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
+      - name: Bump version on a release branch
+        id: bump
         run: |
+          # Read current to detect no-op bumps (shouldn't happen with
+          # npm version <bump>, but bail loudly if it does).
+          BEFORE=$(node -p "require('./package.json').version")
           npm version ${{ inputs.bump }} --no-git-tag-version
-          VERSION=$(node -p "require('./package.json').version")
+          AFTER=$(node -p "require('./package.json').version")
+          if [ "$BEFORE" = "$AFTER" ]; then
+            echo "::error::npm version produced no change ($BEFORE == $AFTER)"
+            exit 1
+          fi
+
+          BRANCH="release/v${AFTER}"
+          echo "version=${AFTER}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          # Use -B so a stale branch from a prior failed attempt is
+          # reset in place rather than making us error out.
+          git checkout -B "${BRANCH}"
           git add package.json
           if [ -f package-lock.json ]; then
             git add package-lock.json
           fi
-          git commit -m "release: v${VERSION}"
-          git tag "v${VERSION}"
-          git push origin main --tags
+          git commit -m "release: v${AFTER}"
+
+          # --force-with-lease is a no-op on the first push and only
+          # overwrites a pre-existing branch if its remote ref matches
+          # what we fetched — safe replacement of a stale release
+          # branch from a prior failed run.
+          git push --force-with-lease origin "${BRANCH}"
+
+      - name: Open or update the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="${{ steps.bump.outputs.branch }}"
+          BODY="Automated release PR created by \`release.yml\`. Bumps package.json (and package-lock.json, if present) to \`v${VERSION}\`.
+
+          Once this PR merges to main, \`tag-on-main.yml\` creates the matching \`v${VERSION}\` tag, which triggers \`publish.yml\` to publish the package to npm.
+
+          Review the diff for any surprises (package-lock.json regeneration drift, etc.) before approving."
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "release: v${VERSION}" --body "$BODY"
+            echo "Updated existing release PR for $BRANCH"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "release: v${VERSION}" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize release dispatches so two operators can't race on the
+# same `release/v<version>` branch. A queued run picks up after
+# the earlier one finishes.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   open-release-pr:
     name: Open release PR
@@ -69,11 +76,22 @@ jobs:
           fi
           git commit -m "release: v${AFTER}"
 
-          # --force-with-lease is a no-op on the first push and only
-          # overwrites a pre-existing branch if its remote ref matches
-          # what we fetched — safe replacement of a stale release
-          # branch from a prior failed run.
-          git push --force-with-lease origin "${BRANCH}"
+          # Push safely whether or not the branch pre-exists on the
+          # remote. actions/checkout does NOT seed remote-tracking
+          # refs for arbitrary release branches, so bare
+          # `--force-with-lease` has no base and can degrade to
+          # unsafe behaviour. We fetch the remote branch first (if
+          # it exists) and then force-with-lease using the EXPLICIT
+          # ref:sha form so the lease is actually enforced against
+          # a known SHA. If the branch doesn't exist on the remote
+          # yet, a plain push is sufficient and safe.
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            REMOTE_SHA=$(git rev-parse "refs/remotes/origin/${BRANCH}")
+            git push --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}" origin "${BRANCH}"
+          else
+            git push origin "${BRANCH}"
+          fi
 
       - name: Open or update the release PR
         env:

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -113,20 +113,28 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           HEAD_SHA=$(git rev-parse HEAD)
 
-          # `git ls-remote --tags` prints two lines for annotated
-          # tags — the tag OBJECT sha (refs/tags/<tag>) and the
-          # dereferenced commit sha (refs/tags/<tag>^{}). For
-          # lightweight tags it prints only the first. Since we
-          # create tags with `git tag -a`, the `^{}` line is the
-          # one that actually identifies the tagged commit. Prefer
-          # it, and fall back to the non-deref line for lightweight
-          # tags created out of band.
-          REMOTE_OUT=$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null || true)
+          # `git ls-remote --tags` distinguishes tag shapes:
+          #   - annotated tag: two lines — tag OBJECT sha
+          #     (refs/tags/<tag>) and dereferenced commit sha
+          #     (refs/tags/<tag>^{})
+          #   - lightweight tag: one line — commit sha under
+          #     refs/tags/<tag>
+          # Filtering on the exact refname (refs/tags/<tag>)
+          # suppresses the ^{} line, so we MUST ask for both
+          # refspecs explicitly. Otherwise the comparison below
+          # would pick the tag-object sha on annotated tags and
+          # always fail the legitimate-rerun equality check.
+          REMOTE_OUT=$(git ls-remote --tags origin \
+            "refs/tags/${TAG}" \
+            "refs/tags/${TAG}^{}" \
+            2>/dev/null || true)
           if [ -z "$REMOTE_OUT" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Prefer the dereferenced sha if present.
+          # Prefer the dereferenced sha (commit) when the remote
+          # returns both. Fall back to the single-line form for
+          # lightweight tags.
           REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '/\^\{\}$/ {print $1}')
           if [ -z "$REMOTE_SHA" ]; then
             REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1; exit}')

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -51,6 +51,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          # Match the caching used by ci.yml / publish.yml so
+          # cold-start time on every push to main is consistent
+          # across workflows.
+          cache: npm
 
       - name: Detect whether this push changed the package version
         id: version

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -1,0 +1,68 @@
+name: Tag release on main
+
+# Fires on every push to main and creates the `v<version>` tag that
+# matches the current package.json version, IF that tag does not
+# already exist on the remote. The tag push is NOT blocked by the
+# branch ruleset (rules target refs/heads/main only; refs/tags/*
+# is a separate namespace), so the default GITHUB_TOKEN is
+# sufficient and no bypass actor is needed.
+#
+# Idempotent by design: if the tag already exists (e.g. a rebuild
+# of the same commit, or a non-release commit landed on main),
+# the workflow is a no-op.
+#
+# The paired `release.yml` workflow opens a bump PR; merging that
+# PR triggers this workflow, which then creates the tag, which
+# then triggers `publish.yml` (push: tags: ["v*"]).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  maybe-tag:
+    name: Tag current main if package.json version is new
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Read package.json version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether the tag already exists on the remote
+        id: check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          # Query the remote directly so we don't rely on the local
+          # checkout's tag namespace.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists on the remote; nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push the tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag -a "${TAG}" -m "release ${TAG}"
+          git push origin "refs/tags/${TAG}"
+          echo "Created and pushed tag ${TAG}"

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -1,19 +1,27 @@
 name: Tag release on main
 
-# Fires on every push to main and creates the `v<version>` tag that
-# matches the current package.json version, IF that tag does not
-# already exist on the remote. The tag push is NOT blocked by the
-# branch ruleset (rules target refs/heads/main only; refs/tags/*
-# is a separate namespace), so the default GITHUB_TOKEN is
-# sufficient and no bypass actor is needed.
-#
-# Idempotent by design: if the tag already exists (e.g. a rebuild
-# of the same commit, or a non-release commit landed on main),
-# the workflow is a no-op.
+# Fires on every push to main. Decides whether this push IS a
+# release (package.json version changed relative to the previous
+# main SHA) and, if so, creates the matching `v<version>` tag.
+# Non-release commits are a fast no-op.
 #
 # The paired `release.yml` workflow opens a bump PR; merging that
 # PR triggers this workflow, which then creates the tag, which
 # then triggers `publish.yml` (push: tags: ["v*"]).
+#
+# Why the version-change gate: without it, any non-release commit
+# landing on main after a release would see the existing
+# `v<current-version>` tag at a different commit than HEAD and
+# (correctly, in isolation) flag it as the orphan-tag failure
+# mode. But after a normal release, the tag SHOULD keep pointing
+# at the release commit while main moves forward — that's the
+# canonical state, not an error. We only treat "tag exists
+# elsewhere" as an error when THIS push was itself a release
+# (i.e. the version number just changed).
+#
+# Tag push is NOT blocked by the branch ruleset: rules target
+# refs/heads/main only; refs/tags/* is a separate namespace. The
+# default GITHUB_TOKEN is sufficient; no bypass actor needed.
 
 on:
   push:
@@ -44,50 +52,91 @@ jobs:
         with:
           node-version: 20
 
-      - name: Read package.json version
+      - name: Detect whether this push changed the package version
         id: version
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TAG="v${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          TAG="v${CURRENT_VERSION}"
+          echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          # `github.event.before` is 40 zeros on the very first push
+          # to a new branch (or for unusual event shapes). In those
+          # cases we can't compute a diff; be conservative and treat
+          # the push as a release attempt so the tag gets created.
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ -z "$GITHUB_EVENT_BEFORE" ] || [ "$GITHUB_EVENT_BEFORE" = "$ZERO_SHA" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "No previous SHA on this push; treating as release by default."
+            exit 0
+          fi
+
+          # Compare the version at this push's starting SHA to HEAD.
+          # If git can't read package.json at the before-SHA (e.g.
+          # the file is new), we also treat it as a change.
+          PREV_VERSION=$(git show "${GITHUB_EVENT_BEFORE}:package.json" 2>/dev/null | node -e "
+            let buf = ''
+            process.stdin.on('data', c => buf += c)
+            process.stdin.on('end', () => {
+              try { process.stdout.write(JSON.parse(buf).version || '') }
+              catch { process.stdout.write('') }
+            })
+          ")
+          if [ -z "$PREV_VERSION" ] || [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: ${PREV_VERSION:-<unknown>} -> ${CURRENT_VERSION}; this is a release commit."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged at ${CURRENT_VERSION}; non-release commit, no-op."
+          fi
 
       - name: Check whether the tag already exists on the remote
         id: check
+        if: steps.version.outputs.changed == 'true'
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           HEAD_SHA=$(git rev-parse HEAD)
-          # Query the remote directly so we don't rely on the local
-          # checkout's tag namespace. `ls-remote --tags` returns the
-          # tag's target SHA when it exists, and exits non-zero when
-          # it doesn't.
+
+          # `git ls-remote --tags` prints two lines for annotated
+          # tags — the tag OBJECT sha (refs/tags/<tag>) and the
+          # dereferenced commit sha (refs/tags/<tag>^{}). For
+          # lightweight tags it prints only the first. Since we
+          # create tags with `git tag -a`, the `^{}` line is the
+          # one that actually identifies the tagged commit. Prefer
+          # it, and fall back to the non-deref line for lightweight
+          # tags created out of band.
           REMOTE_OUT=$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null || true)
           if [ -z "$REMOTE_OUT" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1}')
+          # Prefer the dereferenced sha if present.
+          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '/\^\{\}$/ {print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1; exit}')
+          fi
+
           if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
             # Tag already points at the commit we'd tag anyway —
-            # a legitimate rerun of tag-on-main on the same main
-            # commit. No-op.
+            # a legitimate rerun on the same main commit. No-op.
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag ${TAG} already points at HEAD ($HEAD_SHA); nothing to do."
           else
-            # Tag exists but points somewhere else. That's exactly
-            # the orphan-tag failure mode this workflow was built
-            # to prevent: publish.yml never fires because no new
-            # tag is pushed, and the current release commit goes
-            # untagged silently. Fail loudly with actionable info.
+            # This push changed the version AND a tag for the new
+            # version already exists at a different commit. Classic
+            # orphan-tag failure mode: publish.yml would not fire
+            # for the current release, and the tag would stay
+            # pointed at a stale commit. Fail loudly.
             echo "::error::Tag ${TAG} exists on the remote but points at ${REMOTE_SHA}, not the current main HEAD ${HEAD_SHA}."
-            echo "::error::This is the orphan-tag failure mode. Delete the stale tag before this release merges:"
+            echo "::error::This is the orphan-tag failure mode. Delete the stale tag and re-run:"
             echo "::error::  git push origin --delete ${TAG}"
-            echo "::error::then re-run this workflow (or re-push to main)."
             exit 1
           fi
 
       - name: Create and push the tag
-        if: steps.check.outputs.exists == 'false'
+        if: steps.version.outputs.changed == 'true' && steps.check.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -56,13 +56,34 @@ jobs:
         id: check
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          HEAD_SHA=$(git rev-parse HEAD)
           # Query the remote directly so we don't rely on the local
-          # checkout's tag namespace.
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag ${TAG} already exists on the remote; nothing to do."
-          else
+          # checkout's tag namespace. `ls-remote --tags` returns the
+          # tag's target SHA when it exists, and exits non-zero when
+          # it doesn't.
+          REMOTE_OUT=$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null || true)
+          if [ -z "$REMOTE_OUT" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1}')
+          if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
+            # Tag already points at the commit we'd tag anyway —
+            # a legitimate rerun of tag-on-main on the same main
+            # commit. No-op.
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already points at HEAD ($HEAD_SHA); nothing to do."
+          else
+            # Tag exists but points somewhere else. That's exactly
+            # the orphan-tag failure mode this workflow was built
+            # to prevent: publish.yml never fires because no new
+            # tag is pushed, and the current release commit goes
+            # untagged silently. Fail loudly with actionable info.
+            echo "::error::Tag ${TAG} exists on the remote but points at ${REMOTE_SHA}, not the current main HEAD ${HEAD_SHA}."
+            echo "::error::This is the orphan-tag failure mode. Delete the stale tag before this release merges:"
+            echo "::error::  git push origin --delete ${TAG}"
+            echo "::error::then re-run this workflow (or re-push to main)."
+            exit 1
           fi
 
       - name: Create and push the tag

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -22,6 +22,14 @@ on:
 permissions:
   contents: write
 
+# Serialize pushes to main so two concurrent release merges can't
+# both observe the tag as absent and then race on `git push`.
+# cancel-in-progress:false because every run MUST complete:
+# cancelling a run would skip tagging a legitimate release commit.
+concurrency:
+  group: tag-on-main
+  cancel-in-progress: false
+
 jobs:
   maybe-tag:
     name: Tag current main if package.json version is new
@@ -64,5 +72,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG="${{ steps.version.outputs.tag }}"
           git tag -a "${TAG}" -m "release ${TAG}"
-          git push origin "refs/tags/${TAG}"
-          echo "Created and pushed tag ${TAG}"
+
+          # Tolerate "already exists" as success. The concurrency
+          # group above serialises runs on main, but a belt-and-
+          # suspenders guard closes the residual race where a user
+          # (or another workflow) created the same tag between our
+          # ls-remote check above and this push. We only swallow the
+          # specific "already exists" failure; any other push error
+          # still surfaces.
+          set +e
+          PUSH_OUT=$(git push origin "refs/tags/${TAG}" 2>&1)
+          PUSH_STATUS=$?
+          set -e
+          echo "$PUSH_OUT"
+          if [ $PUSH_STATUS -eq 0 ]; then
+            echo "Created and pushed tag ${TAG}"
+          elif echo "$PUSH_OUT" | grep -q "already exists"; then
+            echo "Tag ${TAG} was created concurrently; treating as success."
+          else
+            exit $PUSH_STATUS
+          fi

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -74,9 +74,19 @@ jobs:
           fi
 
           # Compare the version at this push's starting SHA to HEAD.
-          # If git can't read package.json at the before-SHA (e.g.
-          # the file is new), we also treat it as a change.
-          PREV_VERSION=$(git show "${GITHUB_EVENT_BEFORE}:package.json" 2>/dev/null | node -e "
+          # If git can't read package.json at the before-SHA (file
+          # introduced in this push, tree rewritten, etc.), we treat
+          # the absence as a version change — the conservative
+          # direction that produces a tag rather than silently
+          # skipping. `|| true` keeps the pipeline's exit status 0
+          # under bash -eo pipefail so the step continues.
+          PREV_JSON=$(git show "${GITHUB_EVENT_BEFORE}:package.json" 2>/dev/null || true)
+          if [ -z "$PREV_JSON" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Previous package.json not readable at ${GITHUB_EVENT_BEFORE}; treating as change."
+            exit 0
+          fi
+          PREV_VERSION=$(printf '%s' "$PREV_JSON" | node -e "
             let buf = ''
             process.stdin.on('data', c => buf += c)
             process.stdin.on('end', () => {


### PR DESCRIPTION
## Summary

Fixes the \"tag already exists\" failures on the Release workflow by switching from direct-push-to-main to a PR-based release flow. Net state you asked for: merges to main stay gated (ruleset satisfied), release still triggered by one workflow dispatch, publish still fires automatically on the resulting tag.

## Root cause of the current failure

The \`Protect main branch\` ruleset has two rules that block direct pushes:

1. **Changes must be made through a pull request** — \`github-actions[bot]\` can't \`git push origin main\` directly.
2. **Waiting for Code Scanning results** — CodeQL wasn't configured in the repo.

The old workflow's \`git push origin main --tags\` hit both. The tag push succeeded anyway because the ruleset only targets \`refs/heads/main\`, which is why every retry got \"v1.0.2 already exists\" — the orphan tag pointed at a commit that never made it to main.

## What changed

- **release.yml**: now creates a \`release/v<version>\` branch with the bump commit and opens/updates a PR to main via \`gh pr create\`. Idempotent via \`--force-with-lease\`; a rerun at the same version reuses the branch.
- **tag-on-main.yml** (new): fires on push to main, reads \`package.json\` version, creates \`v<version>\` tag if absent. Idempotent, safe on any merge style (squash / merge commit / rebase). Tag push is allowed by the ruleset (tags namespace is unrestricted).
- **CodeQL default setup enabled** via API (out-of-band — not a file change here). This satisfies the \`code_scanning\` rule so release PRs can actually merge.

## Flow after this lands

1. Operator runs Release workflow dispatch → opens PR \`release/v1.0.2\`.
2. PR goes through Copilot review + CodeQL + CODEOWNERS approval.
3. PR merges to main.
4. tag-on-main.yml fires, creates \`v1.0.2\` tag.
5. publish.yml (already wired to \`push: tags: v*\`) picks up the tag and publishes to npm.

## Test plan

- [ ] Merge this PR
- [ ] Run Release workflow with \`bump: patch\`
- [ ] Verify release/v1.0.2 PR opens with the bump commit
- [ ] Review + merge the release PR
- [ ] Confirm tag-on-main creates v1.0.2 tag
- [ ] Confirm publish.yml publishes to npm

## Cleanup already done

- Deleted orphan \`v1.0.2\` tags from the remote (twice, across two failed attempts).