### PR TITLE
release: v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ctxr/skill-llm-wiki",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ctxr/skill-llm-wiki",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@xenova/transformers": "2.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctxr/skill-llm-wiki",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Claude Code skill — build, extend, validate, rebuild, fix, and join LLM wikis from any knowledge corpus. Token-efficient retrieval via hierarchical indices, DAG parents, and deterministic rewrite operators.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Automated release PR created by `release.yml`. Bumps package.json (and package-lock.json, if present) to `v1.0.2`.

Once this PR merges to main, `tag-on-main.yml` creates the matching `v1.0.2` tag, which triggers `publish.yml` to publish the package to npm.

Review the diff for any surprises (package-lock.json regeneration drift, etc.) before approving.