### PR TITLE
feat(cli): per-phase progress breadcrumbs on stderr (X.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **CLI progress breadcrumbs (Phase X.9).** Long-running operations (build / rebuild / fix / join) now stream a per-phase breadcrumb to stderr as each orchestrator phase fires:
+  - `[build-20260424-212011-abc123 3] ingest: read 596 source file(s), 589 leaves`
+  - `[build-... 7] operator-convergence: 156 operator(s) applied across 23 iteration(s); ...`
+  - Format: `[<op-id> <phase-index>] <phase-name>: <phase-summary>`
+  - Format matches exactly what the final phase log records in the op-summary payload — no new formatter, just a live mirror of `record()` calls.
+  - Writes to stderr (never stdout) so consumers piping the command's stdout don't conflate phase chatter with the final op-summary payload.
+  - Monotonically-increasing phase index per op, so structured log aggregators can reconstruct phase ordering after multiplexing.
+  - Progress is on by default; suppressed when `--json` is passed (the `skill-llm-wiki/v1` envelope consumer contract requires a clean stderr) or when `LLM_WIKI_NO_PROGRESS=1` is set in the environment (CI / hermetic runs that want the pre-X.9 silent-stderr shape).
+  - Implementation: `scripts/lib/orchestrator.mjs::runOperation` accepts an `onProgress({name, summary, index})` callback that the internal `record()` helper invokes alongside the phase-log push. CLI wires a callback that writes the breadcrumb to stderr; in-process callers can pass their own handler for custom streaming (TUI, structured log shipper, etc.). Progress-hook throws are swallowed — a misbehaving callback never halts the op.
+  - Tests (`tests/unit/cli-progress.test.mjs`, 3 scenarios): stderr breadcrumb shape + monotonic phase index; `LLM_WIKI_NO_PROGRESS=1` suppresses; `--json` suppresses.
 - **Real 11-phase `join` implementation (Phase X.2).** The `join` operation now implements the full pipeline from `guide/operations/ingest/join.md` instead of falling through to the convergence-only stub. The skill can now actually merge N ≥ 2 source wikis into one unified output.
   - **New module `scripts/lib/join.mjs`** exports `runJoin(sources, target, ctx)` and the per-phase helpers (`ingestWiki`, `validateSources`, `planUnion`, `resolveIdCollisions`, `mergeCategoriesWithSameFocus`, `rewireReferences`, `materialisePlan`), plus the canonical `VALID_COLLISION_POLICIES` / `DEFAULT_COLLISION_POLICY` constants.
   - **Pipeline phases (per the methodology):**

--- a/guide/cli.md
+++ b/guide/cli.md
@@ -235,6 +235,7 @@ All top-level operations accept:
 ## UX flags
 
 - `--no-prompt` / env `LLM_WIKI_NO_PROMPT=1` — fail loudly on any ambiguity instead of prompting; emits `INT-12` if the skill would otherwise ask a TTY question.
+- Env `LLM_WIKI_NO_PROGRESS=1` — suppress per-phase progress breadcrumbs that the CLI otherwise streams to stderr during long-running operations (build / rebuild / fix / join). Useful for CI jobs that already capture their own progress or that want the pre-X.9 silent stderr shape. `--json` implicitly sets this (the `skill-llm-wiki/v1` envelope consumer contract requires a clean stderr).
 - `--json` — canonical machine-output flag. Enables the `skill-llm-wiki/v1` envelope on subcommands that emit one (validate, init, heal, rollback) and switches `INT-NN` ambiguity errors to JSON on stderr. The consumer-facing probe subcommands `contract` and `where` always emit JSON when this flag is present.
 - `--json-errors` — legacy alias for `--json`, kept for consumers that adopted the flag before the envelope shipped. Triggers identical behaviour. New code should pass `--json`.
 - `--accept-dirty` — operate on a source inside a dirty user git repo (escape hatch for `INT-08`).

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -850,14 +850,17 @@ async function main() {
     const startedIso = new Date().toISOString();
     // X.9 progress: stream each orchestrator phase's `record()`
     // output to stderr as it fires. On by default for interactive
-    // use; suppressed in JSON mode (the `skill-llm-wiki/v1`
-    // envelope is the only permitted stdout/stderr shape then —
-    // injecting human-readable breadcrumbs would make the stderr
-    // channel non-parseable) and suppressed via
-    // `LLM_WIKI_NO_PROGRESS=1` for CI / hermetic runs that want
-    // the pre-X.9 silent shape. Progress goes to stderr (never
-    // stdout) so consumers piping the command's stdout don't
-    // conflate phase chatter with the final op-summary payload.
+    // use; suppressed in JSON mode so stderr stays reserved for
+    // structured JSON diagnostics/errors (build/rebuild/fix/join
+    // still print their human-readable summary to stdout under
+    // --json, but a consumer tailing stderr under --json expects
+    // it to be empty on success or carry only structured
+    // diagnostics — progress breadcrumbs would mix into that
+    // channel). Also suppressed via `LLM_WIKI_NO_PROGRESS=1` for
+    // CI / hermetic runs that want the pre-X.9 silent shape.
+    // Progress goes to stderr (never stdout) so consumers piping
+    // the command's stdout don't conflate phase chatter with the
+    // final op-summary payload.
     const suppressProgress =
       jsonMode || process.env.LLM_WIKI_NO_PROGRESS === "1";
     const onProgress = suppressProgress

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -848,12 +848,36 @@ async function main() {
     }
     const opId = newOpId(cmd);
     const startedIso = new Date().toISOString();
+    // X.9 progress: stream each orchestrator phase's `record()`
+    // output to stderr as it fires. On by default for interactive
+    // use; suppressed in JSON mode (the `skill-llm-wiki/v1`
+    // envelope is the only permitted stdout/stderr shape then —
+    // injecting human-readable breadcrumbs would make the stderr
+    // channel non-parseable) and suppressed via
+    // `LLM_WIKI_NO_PROGRESS=1` for CI / hermetic runs that want
+    // the pre-X.9 silent shape. Progress goes to stderr (never
+    // stdout) so consumers piping the command's stdout don't
+    // conflate phase chatter with the final op-summary payload.
+    const suppressProgress =
+      jsonMode || process.env.LLM_WIKI_NO_PROGRESS === "1";
+    const onProgress = suppressProgress
+      ? null
+      : (phase) => {
+          try {
+            process.stderr.write(
+              `[${opId} ${phase.index}] ${phase.name}: ${phase.summary}\n`,
+            );
+          } catch {
+            // Best-effort — a closed stderr shouldn't halt the op.
+          }
+        };
     let result;
     try {
       result = await runOperation(plan, {
         opId,
         source: plan.source,
         startedIso,
+        onProgress,
       });
     } catch (err) {
       if (err instanceof NonInteractiveError) {

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -863,15 +863,45 @@ async function main() {
     // final op-summary payload.
     const suppressProgress =
       jsonMode || process.env.LLM_WIKI_NO_PROGRESS === "1";
+    // A closed-stderr scenario (downstream pipe consumer that
+    // drops the stderr pipe, e.g. `… | head`) surfaces two ways:
+    // a synchronous throw on `.write()` (try/catch below), and
+    // an async `'error'` event with code EPIPE that the default
+    // Node handler escalates to an unhandled exception. Attach a
+    // best-effort one-time 'error' listener to swallow EPIPE
+    // while progress is enabled; other stream errors still
+    // surface via Node's default handler so we aren't masking
+    // bugs unrelated to the progress stream.
+    let stderrEpipeSilenced = false;
     const onProgress = suppressProgress
       ? null
       : (phase) => {
+          if (!stderrEpipeSilenced) {
+            stderrEpipeSilenced = true;
+            try {
+              process.stderr.on("error", (err) => {
+                if (err && err.code === "EPIPE") return;
+                // Re-emit non-EPIPE errors so we don't hide real
+                // problems — Node's default handler will decide.
+                throw err;
+              });
+            } catch {
+              /* attach failed — progress reporter will best-effort */
+            }
+          }
+          // `.destroyed` / `.writableEnded` guards let us skip the
+          // write before it would throw, which is cheaper than
+          // catching the exception and matches the behaviour on
+          // an already-closed stream.
+          if (process.stderr.destroyed || process.stderr.writableEnded) {
+            return;
+          }
           try {
             process.stderr.write(
               `[${opId} ${phase.index}] ${phase.name}: ${phase.summary}\n`,
             );
           } catch {
-            // Best-effort — a closed stderr shouldn't halt the op.
+            /* Best-effort — a closed stderr shouldn't halt the op. */
           }
         };
     let result;

--- a/scripts/lib/orchestrator.mjs
+++ b/scripts/lib/orchestrator.mjs
@@ -88,9 +88,11 @@ export async function runOperation(plan, {
   // progress to the user in real time — a 596-leaf deterministic
   // build otherwise prints nothing for 2+ minutes. Shape:
   //   (phase: { name: string, summary: string, index: number }) => void
-  // The hook runs synchronously; errors bubble to the caller.
-  // When absent, runOperation is silent on phase progression
-  // (preserving the pre-X.9 behaviour tests may have relied on).
+  // The hook runs synchronously; any errors it throws are caught
+  // and swallowed inside `record()` so a misbehaving progress
+  // reporter can never halt the operation. When absent,
+  // `runOperation` is silent on phase progression (preserving the
+  // pre-X.9 behaviour tests may have relied on).
   onProgress = null,
 } = {}) {
   if (!plan || !plan.target) {

--- a/scripts/lib/orchestrator.mjs
+++ b/scripts/lib/orchestrator.mjs
@@ -79,7 +79,20 @@ import {
 // { operation, layout_mode, source, target, is_new_wiki, flags }.
 // Returns { op_id, final_sha, phases: [...] } on success; throws on
 // validation failure (after rolling the working tree back to pre-op).
-export async function runOperation(plan, { opId, source, startedIso } = {}) {
+export async function runOperation(plan, {
+  opId,
+  source,
+  startedIso,
+  // Optional per-phase progress hook. Invoked inside `record()`
+  // so the caller (typically CLI) can surface phase-by-phase
+  // progress to the user in real time — a 596-leaf deterministic
+  // build otherwise prints nothing for 2+ minutes. Shape:
+  //   (phase: { name: string, summary: string, index: number }) => void
+  // The hook runs synchronously; errors bubble to the caller.
+  // When absent, runOperation is silent on phase progression
+  // (preserving the pre-X.9 behaviour tests may have relied on).
+  onProgress = null,
+} = {}) {
   if (!plan || !plan.target) {
     throw new Error("runOperation requires a resolved plan with a target");
   }
@@ -91,7 +104,17 @@ export async function runOperation(plan, { opId, source, startedIso } = {}) {
   mkdirSync(workDir, { recursive: true });
 
   const phases = [];
-  const record = (name, summary) => phases.push({ name, summary });
+  const record = (name, summary) => {
+    const phase = { name, summary };
+    phases.push(phase);
+    if (onProgress) {
+      try {
+        onProgress({ name, summary, index: phases.length });
+      } catch {
+        // Progress hook failures must never halt the op.
+      }
+    }
+  };
 
   // `join` is the one top-level operation whose pipeline shape does
   // not match the build/rebuild/fix family. Instead of threading

--- a/scripts/lib/orchestrator.mjs
+++ b/scripts/lib/orchestrator.mjs
@@ -110,10 +110,25 @@ export async function runOperation(plan, {
     const phase = { name, summary };
     phases.push(phase);
     if (onProgress) {
+      // Two failure modes to cover: a synchronous throw, and a
+      // returned Promise that rejects (an `async` hook never
+      // throws synchronously — the rejection escapes as an
+      // unhandledRejection and would terminate the process under
+      // Node's default policy, violating the "progress-hook
+      // failures must never halt the op" contract). The try/catch
+      // handles the sync throw; `Promise.resolve(...).catch()`
+      // handles the async rejection. Both swallow silently — a
+      // user with a broken progress reporter should still get a
+      // successful op completion.
       try {
-        onProgress({ name, summary, index: phases.length });
+        const ret = onProgress({ name, summary, index: phases.length });
+        if (ret && typeof ret.then === "function") {
+          Promise.resolve(ret).catch(() => {
+            /* async progress-hook rejection silently swallowed */
+          });
+        }
       } catch {
-        // Progress hook failures must never halt the op.
+        /* sync progress-hook throw silently swallowed */
       }
     }
   };

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -1,0 +1,134 @@
+// cli-progress.test.mjs — X.9 phase-progress streaming to stderr.
+//
+// The orchestrator's `record(name, summary)` internally pushes
+// each phase into `phases[]` and invokes `onProgress` if the
+// caller supplied one. The CLI wires a progress callback that
+// writes `[<op-id> <index>] <phase>: <summary>\n` to stderr.
+// This file pins three contracts:
+//
+//   1. `runOperation({ onProgress })` fires the callback once per
+//      phase, in order, with the running index.
+//   2. The CLI's stderr breadcrumbs appear during a build.
+//   3. `LLM_WIKI_NO_PROGRESS=1` suppresses the breadcrumbs (CI /
+//      hermetic runs) without affecting exit code or phase output.
+//   4. `--json` implicitly suppresses the breadcrumbs — the
+//      JSON-envelope consumer contract requires a clean stderr.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const CLI = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+  "cli.mjs",
+);
+
+function tmpParent(tag) {
+  const d = join(
+    tmpdir(),
+    `skill-llm-wiki-progress-${tag}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function runCli(args, opts = {}) {
+  return spawnSync("node", [CLI, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      LLM_WIKI_NO_PROMPT: "1",
+      LLM_WIKI_MOCK_TIER1: "1",
+      LLM_WIKI_SKIP_CLUSTER_NEST: "1",
+      ...(opts.env || {}),
+    },
+    cwd: opts.cwd,
+  });
+}
+
+function buildTinySource(parent, leaves) {
+  const src = join(parent, "src");
+  mkdirSync(join(src, "notes"), { recursive: true });
+  for (const id of leaves) {
+    writeFileSync(
+      join(src, "notes", `${id}.md`),
+      `# ${id}\n\ndistinctive body for ${id}\n`,
+    );
+  }
+  return src;
+}
+
+test("cli progress: stderr carries phase breadcrumbs on a build", () => {
+  const parent = tmpParent("on");
+  try {
+    const src = buildTinySource(parent, ["alpha", "beta"]);
+    const r = runCli(["build", src]);
+    assert.equal(r.status, 0, r.stderr);
+    // At least one canonical phase breadcrumb must appear.
+    assert.match(
+      r.stderr,
+      /\[build-\S+ \d+\] snapshot:/,
+      `expected a snapshot-phase breadcrumb in stderr; got:\n${r.stderr}`,
+    );
+    assert.match(
+      r.stderr,
+      /\[build-\S+ \d+\] validation:/,
+      `expected a validation-phase breadcrumb in stderr; got:\n${r.stderr}`,
+    );
+    // Breadcrumbs carry a monotonically-increasing index per op.
+    const indices = [...r.stderr.matchAll(/\[build-\S+ (\d+)\]/g)].map((m) =>
+      Number(m[1]),
+    );
+    for (let i = 1; i < indices.length; i++) {
+      assert.ok(
+        indices[i] >= indices[i - 1],
+        `phase index must not decrease; saw ${indices}`,
+      );
+    }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("cli progress: LLM_WIKI_NO_PROGRESS=1 suppresses breadcrumbs", () => {
+  const parent = tmpParent("off");
+  try {
+    const src = buildTinySource(parent, ["alpha", "beta"]);
+    const r = runCli(["build", src], { env: { LLM_WIKI_NO_PROGRESS: "1" } });
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(
+      r.stderr,
+      /\[build-\S+ \d+\]/,
+      `LLM_WIKI_NO_PROGRESS must suppress phase breadcrumbs; got:\n${r.stderr}`,
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("cli progress: --json suppresses breadcrumbs for the envelope contract", () => {
+  const parent = tmpParent("json");
+  try {
+    const src = buildTinySource(parent, ["alpha", "beta"]);
+    const r = runCli(["build", src, "--json"]);
+    // Build in JSON mode emits the envelope on stdout; stderr
+    // must not carry phase breadcrumbs that would pollute a
+    // consumer piping stderr to a log aggregator expecting
+    // structured output.
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(
+      r.stderr,
+      /\[build-\S+ \d+\]/,
+      `--json must suppress progress breadcrumbs; got:\n${r.stderr}`,
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -4,15 +4,17 @@
 // each phase into `phases[]` and invokes `onProgress` if the
 // caller supplied one. The CLI wires a progress callback that
 // writes `[<op-id> <index>] <phase>: <summary>\n` to stderr.
-// This file pins three contracts:
+// This file pins four contracts:
 //
 //   1. `runOperation({ onProgress })` fires the callback once per
-//      phase, in order, with the running index.
+//      phase, in order, with a monotonic running index. (Exercised
+//      indirectly through the CLI breadcrumb shape below, which is
+//      what real callers actually observe.)
 //   2. The CLI's stderr breadcrumbs appear during a build.
 //   3. `LLM_WIKI_NO_PROGRESS=1` suppresses the breadcrumbs (CI /
 //      hermetic runs) without affecting exit code or phase output.
-//   4. `--json` implicitly suppresses the breadcrumbs — the
-//      JSON-envelope consumer contract requires a clean stderr.
+//   4. `--json` implicitly suppresses the breadcrumbs so stderr
+//      stays reserved for structured JSON diagnostics.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -118,10 +120,13 @@ test("cli progress: --json suppresses breadcrumbs for the envelope contract", ()
   try {
     const src = buildTinySource(parent, ["alpha", "beta"]);
     const r = runCli(["build", src, "--json"]);
-    // Build in JSON mode emits the envelope on stdout; stderr
-    // must not carry phase breadcrumbs that would pollute a
-    // consumer piping stderr to a log aggregator expecting
-    // structured output.
+    // In `--json` mode, stderr must stay free of phase
+    // breadcrumbs so machine-oriented consumers and log
+    // pipelines do not receive extra human-readable progress
+    // lines mixed into structured handling paths. (The build
+    // path still prints its human-readable completion summary to
+    // stdout under --json; this test only pins the stderr
+    // contract.)
     assert.equal(r.status, 0, r.stderr);
     assert.doesNotMatch(
       r.stderr,


### PR DESCRIPTION
## Summary

Long-running operations (build / rebuild / fix / join) now stream a per-phase breadcrumb to stderr as each orchestrator phase fires. Before X.9 a 596-leaf deterministic build printed nothing for 2+ minutes; now the user sees every phase's \`record(name, summary)\` output in real time.

## Format

\`\`\`
[build-20260424-212011-abc123 3] ingest: read 596 source file(s), 589 leaves
[build-20260424-212011-abc123 7] operator-convergence: 156 operator(s) applied across 23 iteration(s); ...
\`\`\`

- Format mirrors exactly what the final phase log records in the op-summary payload — no new formatter, just a live mirror of \`record()\` calls.
- Writes to **stderr** (never stdout) so consumers piping the command's stdout don't conflate phase chatter with the final op-summary payload.
- Monotonically-increasing phase index per op, so structured log aggregators can reconstruct phase ordering after multiplexing.

## Suppression

- **\`--json\`** implicitly suppresses (the \`skill-llm-wiki/v1\` envelope consumer contract requires a clean stderr).
- **\`LLM_WIKI_NO_PROGRESS=1\`** env var for CI / hermetic runs that want the pre-X.9 silent-stderr shape.

## Implementation

- \`scripts/lib/orchestrator.mjs::runOperation\` accepts an \`onProgress({name, summary, index})\` callback that the internal \`record()\` helper invokes alongside the phase-log push.
- CLI wires a default callback that writes the breadcrumb to stderr.
- In-process callers can pass their own handler for custom streaming (TUI, structured log shipper, etc.).
- Progress-hook throws are swallowed — a misbehaving callback never halts the op.

## Test plan

- [x] 3 new CLI scenarios in \`tests/unit/cli-progress.test.mjs\`:
   - stderr breadcrumb shape + monotonic phase index on a build
   - \`LLM_WIKI_NO_PROGRESS=1\` suppresses breadcrumbs
   - \`--json\` suppresses breadcrumbs
- [x] Full suite: 712 pass / 0 fail / 3 skipped
- [x] \`npm run lint\` clean
- [x] guide/cli.md UX section documents the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)