### PR TITLE
fix(cli-progress): stream join phases + strict monotonic test (PR #17 follow-up)

### DIFF
--- a/scripts/lib/join.mjs
+++ b/scripts/lib/join.mjs
@@ -717,10 +717,21 @@ export async function runJoin(sources, target, ctx = {}) {
   const record = (name, summary) => {
     phaseLog.push({ name, summary });
     if (onPhase) {
+      // Cover BOTH sync throws and async rejections from the hook
+      // (mirrors `orchestrator.mjs::record()`). An `async` onPhase
+      // that rejects would otherwise escape as unhandledRejection
+      // and could terminate the process under Node's default
+      // policy, violating the "progress hook failures never halt
+      // the op" contract.
       try {
-        onPhase({ phase: name, summary });
+        const ret = onPhase({ phase: name, summary });
+        if (ret && typeof ret.then === "function") {
+          Promise.resolve(ret).catch(() => {
+            /* async onPhase rejection silently swallowed */
+          });
+        }
       } catch {
-        /* progress hook throws never halt the op */
+        /* sync onPhase throw silently swallowed */
       }
     }
   };

--- a/scripts/lib/join.mjs
+++ b/scripts/lib/join.mjs
@@ -695,6 +695,17 @@ export async function runJoin(sources, target, ctx = {}) {
     // runs end-to-end without intermediate commits — the shape tests
     // in `tests/unit/join.test.mjs` use that path.
     onPhaseCommit = null,
+    // Optional per-phase progress hook, invoked synchronously the
+    // moment each phase records its summary (i.e. BEFORE the op
+    // awaits the next phase's I/O). This is what makes CLI-level
+    // progress streaming work for join — without it the
+    // orchestrator only sees join's phases AFTER `runJoin`
+    // returns, so the `[<op-id> N] phase: summary` breadcrumbs
+    // batch-print at the end of the join instead of streaming
+    // during execution. Shape: ({ phase, summary }) => void.
+    // Errors are swallowed — a misbehaving progress hook must
+    // never halt the op.
+    onPhase = null,
   } = ctx;
   const commitPhase = async (phase, summary) => {
     if (onPhaseCommit) await onPhaseCommit({ phase, summary });
@@ -703,7 +714,16 @@ export async function runJoin(sources, target, ctx = {}) {
     throw new Error(`join: at least 2 source wikis required, got ${sources?.length ?? 0}`);
   }
   const phaseLog = [];
-  const record = (name, summary) => phaseLog.push({ name, summary });
+  const record = (name, summary) => {
+    phaseLog.push({ name, summary });
+    if (onPhase) {
+      try {
+        onPhase({ phase: name, summary });
+      } catch {
+        /* progress hook throws never halt the op */
+      }
+    }
+  };
 
   // Phase 1 — ingest-all.
   const ingested = sources.map((s) => ingestWiki(s));

--- a/scripts/lib/join.mjs
+++ b/scripts/lib/join.mjs
@@ -702,9 +702,14 @@ export async function runJoin(sources, target, ctx = {}) {
     // orchestrator only sees join's phases AFTER `runJoin`
     // returns, so the `[<op-id> N] phase: summary` breadcrumbs
     // batch-print at the end of the join instead of streaming
-    // during execution. Shape: ({ phase, summary }) => void.
-    // Errors are swallowed — a misbehaving progress hook must
-    // never halt the op.
+    // during execution. Shape:
+    //   ({ phase, summary }) => any | Promise<any>
+    // The return value is ignored. Synchronous throws AND Promise
+    // rejections are both swallowed — a misbehaving progress hook
+    // must never halt the op. Async hooks are supported (the
+    // caller is responsible for ensuring their observable side
+    // effects don't race with subsequent phases; `runJoin` itself
+    // does not await the hook).
     onPhase = null,
   } = ctx;
   const commitPhase = async (phase, summary) => {

--- a/scripts/lib/orchestrator.mjs
+++ b/scripts/lib/orchestrator.mjs
@@ -166,8 +166,21 @@ export async function runOperation(plan, {
             gitCommit(wikiRoot, `phase ${phase}: ${summary}`);
           }
         },
+        // Stream join's phases through the orchestrator's own
+        // `record()` the moment each one fires — that routes the
+        // phase into the outer `phases[]` AND invokes the CLI's
+        // `onProgress` breadcrumb callback in real time. Without
+        // this hook we'd only see join's phases relayed AFTER
+        // `runJoin` returns (the pre-X.9-followup post-call
+        // `for (const p of result.phases)` loop), which made the
+        // whole join look like one silent block in the breadcrumb
+        // stream. runJoin's `phaseLog` still accumulates for the
+        // returned-result shape, but the outer `phases[]` now
+        // gets populated live.
+        onPhase: ({ phase, summary }) => {
+          record(phase, summary);
+        },
       });
-      for (const p of result.phases) record(p.name, p.summary);
       // Tier 2 suspend: convergence parked decisions that can't be
       // resolved without a sub-agent. Drain the pending queue,
       // write the batch, and throw NeedsTier2Error — the caller

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -18,7 +18,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -105,24 +105,29 @@ test("cli progress: stderr carries phase breadcrumbs on a build", () => {
   }
 });
 
-test("cli progress: join streams per-phase breadcrumbs during execution", () => {
+test("cli progress: join streams per-phase breadcrumbs during execution", async () => {
   // Regression for the PR-17-followup fix: before runJoin grew
   // an `onPhase` callback, the orchestrator's join branch only
   // relayed join's sub-phases into the outer phases[] AFTER
   // runJoin returned, so the stderr breadcrumbs all printed at
   // the end of the join instead of during it. This test pins
-  // that join's own phase names (ingest-all, plan-union,
-  // resolve-id-collisions, …) show up in stderr with consecutive
-  // phase indices — proof that `onPhase` is wired through to the
-  // CLI breadcrumb callback in real time.
+  // the streaming contract two ways:
+  //   (1) Final stderr carries the expected per-phase
+  //       breadcrumbs with consecutive indices from 1.
+  //   (2) The first join breadcrumb is observed BEFORE the
+  //       child process exits — proof that the breadcrumb
+  //       arrived as part of the streaming output, not flushed
+  //       in a single batch at process-exit. This is the part
+  //       a `spawnSync`-based test couldn't distinguish: it
+  //       only sees stderr after the process is gone, so a
+  //       regression to batch-at-end emission would still pass
+  //       under a sync-spawn check.
   const parent = tmpParent("join");
   try {
     const srcA = buildTinySource(parent, ["alpha-src"]);
-    // Build the first source into a wiki.
     const buildA = runCli(["build", srcA]);
     assert.equal(buildA.status, 0, buildA.stderr);
     const wikiA = `${srcA}.wiki`;
-    // Build a second source (distinct subcat + leaves).
     const srcBRoot = join(parent, "srcB");
     mkdirSync(join(srcBRoot, "other"), { recursive: true });
     writeFileSync(
@@ -132,44 +137,73 @@ test("cli progress: join streams per-phase breadcrumbs during execution", () => 
     const buildB = runCli(["build", srcBRoot]);
     assert.equal(buildB.status, 0, buildB.stderr);
     const wikiB = `${srcBRoot}.wiki`;
-    // Run the actual join; progress breadcrumbs should stream.
+    // Async-spawn the join so we can listen to stderr `data`
+    // events as they arrive. `child.exitCode` is null while the
+    // process is alive and gets set only at exit, so checking
+    // it inside the `data` handler tells us whether the
+    // breadcrumb arrived during execution or post-exit.
     const target = join(parent, "joined.wiki");
-    const r = runCli([
-      "join",
-      wikiA,
-      wikiB,
-      "--target",
-      target,
-      "--quality-mode",
-      "deterministic",
-    ]);
-    assert.equal(r.status, 0, r.stderr);
-    // Each join sub-phase must appear as a `[join-... N] <phase>:`
-    // breadcrumb. Check a couple of representative ones that
-    // `runJoin` always records on a 2-source clean-merge run.
+    const child = spawn(
+      "node",
+      [
+        CLI,
+        "join",
+        wikiA,
+        wikiB,
+        "--target",
+        target,
+        "--quality-mode",
+        "deterministic",
+      ],
+      {
+        env: {
+          ...process.env,
+          LLM_WIKI_NO_PROMPT: "1",
+          LLM_WIKI_MOCK_TIER1: "1",
+          LLM_WIKI_SKIP_CLUSTER_NEST: "1",
+        },
+      },
+    );
+    let stderr = "";
+    let breadcrumbDuringExecution = false;
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (child.exitCode === null && /\[join-\S+ \d+\] /.test(stderr)) {
+        breadcrumbDuringExecution = true;
+      }
+    });
+    const exitCode = await new Promise((resolve) => {
+      child.on("exit", (code) => resolve(code));
+    });
+    assert.equal(exitCode, 0, stderr);
+    assert.ok(
+      breadcrumbDuringExecution,
+      `expected at least one join breadcrumb to arrive BEFORE process exit (proof that emission streams rather than batching at end); final stderr was:\n${stderr}`,
+    );
+    // Now also verify the final shape — every join sub-phase
+    // appears, and indices are consecutive from 1.
     assert.match(
-      r.stderr,
+      stderr,
       /\[join-\S+ \d+\] ingest-all:/,
-      `expected ingest-all breadcrumb; got:\n${r.stderr}`,
+      `expected ingest-all breadcrumb; got:\n${stderr}`,
     );
     assert.match(
-      r.stderr,
+      stderr,
       /\[join-\S+ \d+\] plan-union:/,
-      `expected plan-union breadcrumb; got:\n${r.stderr}`,
+      `expected plan-union breadcrumb; got:\n${stderr}`,
     );
     assert.match(
-      r.stderr,
+      stderr,
       /\[join-\S+ \d+\] validation:/,
-      `expected validation breadcrumb; got:\n${r.stderr}`,
+      `expected validation breadcrumb; got:\n${stderr}`,
     );
-    // And the index sequence is consecutive from 1 for the join
-    // op's breadcrumbs.
-    const joinIndices = [...r.stderr.matchAll(/\[join-\S+ (\d+)\]/g)].map(
+    const joinIndices = [...stderr.matchAll(/\[join-\S+ (\d+)\]/g)].map(
       (m) => Number(m[1]),
     );
     assert.ok(
       joinIndices.length > 0,
-      `expected at least one join breadcrumb; got:\n${r.stderr}`,
+      `expected at least one join breadcrumb; got:\n${stderr}`,
     );
     for (let i = 0; i < joinIndices.length; i++) {
       assert.equal(

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -88,12 +88,10 @@ test("cli progress: stderr carries phase breadcrumbs on a build", () => {
     const indices = [...r.stderr.matchAll(/\[build-\S+ (\d+)\]/g)].map((m) =>
       Number(m[1]),
     );
-    // Strictly increasing: the "one callback per phase" contract
-    // would be undermined by duplicates (two callbacks for the
-    // same phase index), so `>` rather than `>=` is the right
-    // gate to pin it. Also assert the sequence starts at 1 and
-    // has no gaps — together this rules out skipped-phase
-    // regressions as well.
+    // Assert the exact "one callback per phase, in order" contract:
+    // indices must form the consecutive sequence 1, 2, 3, … with
+    // no duplicates and no gaps. That also rules out
+    // skipped-phase regressions.
     assert.ok(indices.length > 0, "expected at least one phase breadcrumb");
     for (let i = 0; i < indices.length; i++) {
       assert.equal(

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -154,6 +154,12 @@ test("cli progress: join emits per-phase breadcrumbs in stderr (final shape)", a
           LLM_WIKI_MOCK_TIER1: "1",
           LLM_WIKI_SKIP_CLUSTER_NEST: "1",
         },
+        // Drop stdin + stdout. The CLI writes a completion summary
+        // and per-phase bullet list to stdout under `join`; if we
+        // piped it without draining, a long-enough run could block
+        // the child on a full pipe buffer and hang the test. We
+        // only need stderr (the breadcrumb stream) here.
+        stdio: ["ignore", "ignore", "pipe"],
       },
     );
     let stderr = "";

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -88,10 +88,18 @@ test("cli progress: stderr carries phase breadcrumbs on a build", () => {
     const indices = [...r.stderr.matchAll(/\[build-\S+ (\d+)\]/g)].map((m) =>
       Number(m[1]),
     );
-    for (let i = 1; i < indices.length; i++) {
-      assert.ok(
-        indices[i] >= indices[i - 1],
-        `phase index must not decrease; saw ${indices}`,
+    // Strictly increasing: the "one callback per phase" contract
+    // would be undermined by duplicates (two callbacks for the
+    // same phase index), so `>` rather than `>=` is the right
+    // gate to pin it. Also assert the sequence starts at 1 and
+    // has no gaps — together this rules out skipped-phase
+    // regressions as well.
+    assert.ok(indices.length > 0, "expected at least one phase breadcrumb");
+    for (let i = 0; i < indices.length; i++) {
+      assert.equal(
+        indices[i],
+        i + 1,
+        `phase index at position ${i} must equal ${i + 1}, got ${indices[i]}; full sequence: ${indices.join(", ")}`,
       );
     }
   } finally {

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -105,6 +105,84 @@ test("cli progress: stderr carries phase breadcrumbs on a build", () => {
   }
 });
 
+test("cli progress: join streams per-phase breadcrumbs during execution", () => {
+  // Regression for the PR-17-followup fix: before runJoin grew
+  // an `onPhase` callback, the orchestrator's join branch only
+  // relayed join's sub-phases into the outer phases[] AFTER
+  // runJoin returned, so the stderr breadcrumbs all printed at
+  // the end of the join instead of during it. This test pins
+  // that join's own phase names (ingest-all, plan-union,
+  // resolve-id-collisions, …) show up in stderr with consecutive
+  // phase indices — proof that `onPhase` is wired through to the
+  // CLI breadcrumb callback in real time.
+  const parent = tmpParent("join");
+  try {
+    const srcA = buildTinySource(parent, ["alpha-src"]);
+    // Build the first source into a wiki.
+    const buildA = runCli(["build", srcA]);
+    assert.equal(buildA.status, 0, buildA.stderr);
+    const wikiA = `${srcA}.wiki`;
+    // Build a second source (distinct subcat + leaves).
+    const srcBRoot = join(parent, "srcB");
+    mkdirSync(join(srcBRoot, "other"), { recursive: true });
+    writeFileSync(
+      join(srcBRoot, "other", "beta-src.md"),
+      "# Beta\n\ndistinct beta content\n",
+    );
+    const buildB = runCli(["build", srcBRoot]);
+    assert.equal(buildB.status, 0, buildB.stderr);
+    const wikiB = `${srcBRoot}.wiki`;
+    // Run the actual join; progress breadcrumbs should stream.
+    const target = join(parent, "joined.wiki");
+    const r = runCli([
+      "join",
+      wikiA,
+      wikiB,
+      "--target",
+      target,
+      "--quality-mode",
+      "deterministic",
+    ]);
+    assert.equal(r.status, 0, r.stderr);
+    // Each join sub-phase must appear as a `[join-... N] <phase>:`
+    // breadcrumb. Check a couple of representative ones that
+    // `runJoin` always records on a 2-source clean-merge run.
+    assert.match(
+      r.stderr,
+      /\[join-\S+ \d+\] ingest-all:/,
+      `expected ingest-all breadcrumb; got:\n${r.stderr}`,
+    );
+    assert.match(
+      r.stderr,
+      /\[join-\S+ \d+\] plan-union:/,
+      `expected plan-union breadcrumb; got:\n${r.stderr}`,
+    );
+    assert.match(
+      r.stderr,
+      /\[join-\S+ \d+\] validation:/,
+      `expected validation breadcrumb; got:\n${r.stderr}`,
+    );
+    // And the index sequence is consecutive from 1 for the join
+    // op's breadcrumbs.
+    const joinIndices = [...r.stderr.matchAll(/\[join-\S+ (\d+)\]/g)].map(
+      (m) => Number(m[1]),
+    );
+    assert.ok(
+      joinIndices.length > 0,
+      `expected at least one join breadcrumb; got:\n${r.stderr}`,
+    );
+    for (let i = 0; i < joinIndices.length; i++) {
+      assert.equal(
+        joinIndices[i],
+        i + 1,
+        `join phase index at position ${i} must equal ${i + 1}, got ${joinIndices[i]}; full sequence: ${joinIndices.join(", ")}`,
+      );
+    }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 test("cli progress: LLM_WIKI_NO_PROGRESS=1 suppresses breadcrumbs", () => {
   const parent = tmpParent("off");
   try {

--- a/tests/unit/cli-progress.test.mjs
+++ b/tests/unit/cli-progress.test.mjs
@@ -105,23 +105,20 @@ test("cli progress: stderr carries phase breadcrumbs on a build", () => {
   }
 });
 
-test("cli progress: join streams per-phase breadcrumbs during execution", async () => {
-  // Regression for the PR-17-followup fix: before runJoin grew
-  // an `onPhase` callback, the orchestrator's join branch only
-  // relayed join's sub-phases into the outer phases[] AFTER
-  // runJoin returned, so the stderr breadcrumbs all printed at
-  // the end of the join instead of during it. This test pins
-  // the streaming contract two ways:
-  //   (1) Final stderr carries the expected per-phase
-  //       breadcrumbs with consecutive indices from 1.
-  //   (2) The first join breadcrumb is observed BEFORE the
-  //       child process exits — proof that the breadcrumb
-  //       arrived as part of the streaming output, not flushed
-  //       in a single batch at process-exit. This is the part
-  //       a `spawnSync`-based test couldn't distinguish: it
-  //       only sees stderr after the process is gone, so a
-  //       regression to batch-at-end emission would still pass
-  //       under a sync-spawn check.
+test("cli progress: join emits per-phase breadcrumbs in stderr (final shape)", async () => {
+  // CLI-side check: a `join` invocation's stderr carries the
+  // expected per-phase breadcrumb names with consecutive indices
+  // from 1. This is a final-shape test — it verifies the wiring
+  // from `runJoin`'s `onPhase` through the orchestrator's
+  // `record()` to the CLI's `onProgress` writer reaches stderr,
+  // but it intentionally does NOT try to distinguish "streamed
+  // during execution" from "batched at end" via stderr timing.
+  // That distinction is unreliable from a black-box CLI runner
+  // (the regressed code path also wrote breadcrumbs before
+  // process exit, just not interleaved with join's phases). The
+  // streaming-vs-batching contract is pinned by a direct
+  // in-process test on `runJoin`'s `onPhase` in
+  // tests/unit/join.test.mjs.
   const parent = tmpParent("join");
   try {
     const srcA = buildTinySource(parent, ["alpha-src"]);
@@ -137,11 +134,6 @@ test("cli progress: join streams per-phase breadcrumbs during execution", async 
     const buildB = runCli(["build", srcBRoot]);
     assert.equal(buildB.status, 0, buildB.stderr);
     const wikiB = `${srcBRoot}.wiki`;
-    // Async-spawn the join so we can listen to stderr `data`
-    // events as they arrive. `child.exitCode` is null while the
-    // process is alive and gets set only at exit, so checking
-    // it inside the `data` handler tells us whether the
-    // breadcrumb arrived during execution or post-exit.
     const target = join(parent, "joined.wiki");
     const child = spawn(
       "node",
@@ -165,24 +157,21 @@ test("cli progress: join streams per-phase breadcrumbs during execution", async 
       },
     );
     let stderr = "";
-    let breadcrumbDuringExecution = false;
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk) => {
       stderr += chunk;
-      if (child.exitCode === null && /\[join-\S+ \d+\] /.test(stderr)) {
-        breadcrumbDuringExecution = true;
-      }
     });
-    const exitCode = await new Promise((resolve) => {
-      child.on("exit", (code) => resolve(code));
+    // Listen on `close` rather than `exit`: `exit` fires when the
+    // process ends but stdio buffers may still flush afterwards;
+    // `close` is the reliable "all stdio drained" signal so we
+    // don't race with late-arriving stderr chunks. Also wire an
+    // error handler so a spawn failure rejects the test instead
+    // of hanging.
+    const exitCode = await new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code) => resolve(code));
     });
     assert.equal(exitCode, 0, stderr);
-    assert.ok(
-      breadcrumbDuringExecution,
-      `expected at least one join breadcrumb to arrive BEFORE process exit (proof that emission streams rather than batching at end); final stderr was:\n${stderr}`,
-    );
-    // Now also verify the final shape — every join sub-phase
-    // appears, and indices are consecutive from 1.
     assert.match(
       stderr,
       /\[join-\S+ \d+\] ingest-all:/,

--- a/tests/unit/join.test.mjs
+++ b/tests/unit/join.test.mjs
@@ -1,15 +1,12 @@
 // join.test.mjs — unit coverage for the 11-phase join pipeline.
 //
-// Each test builds small source wiki fixtures by hand (the unit
-// scope avoids the full `build` CLI roundtrip — that's covered by
-// the e2e suite) and exercises the individual phase helpers
-// (`ingestWiki`, `validateSources`, `planUnion`, ...). The
-// end-to-end `runJoin` pipeline is not exercised here — the
-// convergence + index-generation + validation tail depends on the
-// full pipeline machinery (Tier 1 embeddings, git snapshots, etc.)
-// and is covered by the e2e build suite once the join operator
-// lands a golden fixture there. Scope of this file: every phase
-// helper's contract in isolation:
+// Most tests in this file build small source-wiki fixtures by hand
+// (raw frontmatter + body writes via writeFm) and exercise
+// individual phase helpers (`ingestWiki`, `validateSources`,
+// `planUnion`, ...) in isolation — the unit scope avoids the full
+// `build` CLI roundtrip wherever possible because the full
+// end-to-end pipeline is covered by the e2e build suite. Scope of
+// the per-helper tests:
 //   - ingestWiki: reads frontmatter + body, skips dotfiles / plain md
 //   - validateSources: per-source findings aggregated
 //   - planUnion: sourceWiki tag preserved
@@ -22,6 +19,16 @@
 //   - materialisePlan: leaves + indices land at expected paths;
 //     dangling-category indices for fully-merged-away directories
 //     are dropped
+//
+// The single exception is `runJoin: onPhase fires DURING execution`
+// (the in-process streaming-contract test added in PR #19). That
+// one test deliberately uses `runCliBuild()` + `spawnSync` to
+// produce two real source wikis with `.llmwiki/git/` markers
+// because the contract under test (onPhase fires before runJoin's
+// promise resolves) requires real ingest-able sources. It sets
+// `LLM_WIKI_MOCK_TIER1=1` + `LLM_WIKI_SKIP_CLUSTER_NEST=1` on the
+// parent process for the runJoin call so the convergence path
+// stays hermetic / offline / fast.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -724,6 +731,23 @@ test("runJoin: onPhase fires DURING execution, not batched after (Promise.race)"
     `skill-llm-wiki-runjoin-stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   );
   mkdirSync(parent, { recursive: true });
+
+  // Hermetic-runtime guard. Deterministic mode still routes
+  // mid-band similarity decisions through Tier 1 (MiniLM via
+  // `tiered.mjs`) and the convergence path may invoke
+  // cluster-nest. In a CLI subprocess `runCliBuild()` sets these
+  // env flags inside the child, but THIS test calls `runJoin`
+  // in-process — without these flags in the parent env, CI runs
+  // could load/download the real MiniLM weights and run real
+  // clustering, which is slow, network-sensitive, and irrelevant
+  // to the streaming-contract assertion below. Save the prior
+  // values so we restore them in `finally`, leaving global state
+  // untouched for sibling tests.
+  const priorMockTier1 = process.env.LLM_WIKI_MOCK_TIER1;
+  const priorSkipClusterNest = process.env.LLM_WIKI_SKIP_CLUSTER_NEST;
+  process.env.LLM_WIKI_MOCK_TIER1 = "1";
+  process.env.LLM_WIKI_SKIP_CLUSTER_NEST = "1";
+
   try {
     // Source A: notes-a/{alpha-src.md}
     const srcA = join(parent, "src-a");
@@ -801,6 +825,10 @@ test("runJoin: onPhase fires DURING execution, not batched after (Promise.race)"
       if (err.code !== "JOIN-TARGET-INVALID") throw err;
     });
   } finally {
+    if (priorMockTier1 === undefined) delete process.env.LLM_WIKI_MOCK_TIER1;
+    else process.env.LLM_WIKI_MOCK_TIER1 = priorMockTier1;
+    if (priorSkipClusterNest === undefined) delete process.env.LLM_WIKI_SKIP_CLUSTER_NEST;
+    else process.env.LLM_WIKI_SKIP_CLUSTER_NEST = priorSkipClusterNest;
     rmSync(parent, { recursive: true, force: true });
   }
 });

--- a/tests/unit/join.test.mjs
+++ b/tests/unit/join.test.mjs
@@ -64,15 +64,25 @@ const CLI = join(
   "cli.mjs",
 );
 function runCliBuild(src) {
-  return spawnSync("node", [CLI, "build", src], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      LLM_WIKI_NO_PROMPT: "1",
-      LLM_WIKI_MOCK_TIER1: "1",
-      LLM_WIKI_SKIP_CLUSTER_NEST: "1",
+  // Pin `--quality-mode deterministic` so the subprocess can never
+  // enqueue Tier 2 work (which would exit-7 with NEEDS_TIER2 under
+  // hermetic test conditions). The default `tiered-fast` mode can
+  // still escalate even with `LLM_WIKI_MOCK_TIER1=1` set; only
+  // deterministic mode resolves every mid-band similarity decision
+  // algorithmically and stays self-contained.
+  return spawnSync(
+    "node",
+    [CLI, "build", src, "--quality-mode", "deterministic"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LLM_WIKI_NO_PROMPT: "1",
+        LLM_WIKI_MOCK_TIER1: "1",
+        LLM_WIKI_SKIP_CLUSTER_NEST: "1",
+      },
     },
-  });
+  );
 }
 
 function tmpWiki(tag) {

--- a/tests/unit/join.test.mjs
+++ b/tests/unit/join.test.mjs
@@ -720,7 +720,10 @@ test("runJoin: onPhase fires DURING execution, not batched after (Promise.race)"
   // ingest-all → … → validation takes a meaningful (~hundreds
   // of ms) amount of time. With deterministic mode (no Tier 2
   // queue), the run is fully self-contained.
-  const parent = tmpdir() + `/skill-llm-wiki-runjoin-stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const parent = join(
+    tmpdir(),
+    `skill-llm-wiki-runjoin-stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
   mkdirSync(parent, { recursive: true });
   try {
     // Source A: notes-a/{alpha-src.md}
@@ -764,13 +767,26 @@ test("runJoin: onPhase fires DURING execution, not batched after (Promise.race)"
 
     const winner = await Promise.race([
       firstPhasePromise.then(() => "phase-fired"),
-      joinPromise.then(() => "join-resolved"),
+      joinPromise.then(() => "join-resolved", () => "join-resolved"),
     ]);
     assert.equal(
       winner,
       "phase-fired",
-      `onPhase("ingest-all") must settle BEFORE runJoin's promise resolves — proves the callback streams during execution rather than batching at end. Observed phases at race time: ${JSON.stringify(observedPhases)}`,
+      `onPhase("ingest-all") must settle BEFORE runJoin's promise resolves — proves the callback wiring exists. The realistic regression this catches is "onPhase support dropped from runJoin" (the wiring this PR adds); the OLD pre-onPhase code path had runJoin's promise resolve before any callback fired, so the race winner would be "join-resolved". Observed phases at race time: ${JSON.stringify(observedPhases)}`,
     );
+
+    // Macrotask-gap timing checks were tried in an earlier
+    // round but proved flaky: a join over two-leaf source
+    // wikis under deterministic mode + LLM_WIKI_MOCK_TIER1
+    // completes in a few hundred microseconds end-to-end with
+    // every internal `await` resolving as a microtask in the
+    // same event-loop turn — `setImmediate` between phases
+    // never gets to fire before runJoin returns, so a
+    // "still-pending after first phase" assertion went both
+    // ways across runs. The Promise.race winner check above
+    // is the authoritative streaming-contract test here; the
+    // CLI-side `cli progress: join emits per-phase
+    // breadcrumbs in stderr` covers the end-to-end shape.
 
     // Cleanup: still need to await runJoin's resolution to
     // avoid an unhandled-promise-rejection warning. The

--- a/tests/unit/join.test.mjs
+++ b/tests/unit/join.test.mjs
@@ -44,8 +44,30 @@ import {
   planUnion,
   resolveIdCollisions,
   rewireReferences,
+  runJoin,
   validateSources,
 } from "../../scripts/lib/join.mjs";
+import { spawnSync } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+const CLI = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+  "cli.mjs",
+);
+function runCliBuild(src) {
+  return spawnSync("node", [CLI, "build", src], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      LLM_WIKI_NO_PROMPT: "1",
+      LLM_WIKI_MOCK_TIER1: "1",
+      LLM_WIKI_SKIP_CLUSTER_NEST: "1",
+    },
+  });
+}
 
 function tmpWiki(tag) {
   const d = join(
@@ -666,5 +688,104 @@ test("materialisePlan: writes leaves + indices under target", () => {
   } finally {
     rmSync(a, { recursive: true, force: true });
     rmSync(out, { recursive: true, force: true });
+  }
+});
+
+// ── runJoin onPhase streaming contract ─────────────────────────
+
+test("runJoin: onPhase fires DURING execution, not batched after (Promise.race)", async () => {
+  // Strongest streaming-contract test for the PR-17-followup
+  // wiring. Earlier CLI-side variants couldn't reliably
+  // distinguish "streamed during execution" from
+  // "batched at end before exit" — both behaviours produce
+  // breadcrumbs in stderr before the process exits.
+  //
+  // This test pins the contract directly via Promise.race:
+  // a Promise that resolves on the FIRST `onPhase` callback
+  // (`ingest-all` is runJoin's first recorded phase) is raced
+  // against runJoin's overall promise. If `onPhase` fires
+  // synchronously inside runJoin's body — as it must under
+  // the streaming contract — the first-phase Promise settles
+  // long before runJoin's promise resolves, and the race
+  // returns "phase-fired". A regression that either dropped
+  // `onPhase` entirely or only invoked it after all I/O
+  // completed would let runJoin's promise win the race
+  // (either because onPhase never fires, or because all
+  // calls happen too close to runJoin's resolution).
+  //
+  // The test uses `spawnSync` to build two real source wikis
+  // via the build CLI — that gives them the `.llmwiki/git/`
+  // private-git markers `validateWiki` requires for source
+  // validation, plus enough I/O downstream that
+  // ingest-all → … → validation takes a meaningful (~hundreds
+  // of ms) amount of time. With deterministic mode (no Tier 2
+  // queue), the run is fully self-contained.
+  const parent = tmpdir() + `/skill-llm-wiki-runjoin-stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  mkdirSync(parent, { recursive: true });
+  try {
+    // Source A: notes-a/{alpha-src.md}
+    const srcA = join(parent, "src-a");
+    mkdirSync(join(srcA, "notes-a"), { recursive: true });
+    writeFileSync(
+      join(srcA, "notes-a", "alpha-src.md"),
+      "# Alpha\n\ndistinct alpha content for streaming test\n",
+    );
+    const buildA = runCliBuild(srcA);
+    assert.equal(buildA.status, 0, buildA.stderr);
+    const wikiA = `${srcA}.wiki`;
+
+    // Source B: notes-b/{beta-src.md}
+    const srcB = join(parent, "src-b");
+    mkdirSync(join(srcB, "notes-b"), { recursive: true });
+    writeFileSync(
+      join(srcB, "notes-b", "beta-src.md"),
+      "# Beta\n\ndistinct beta content for streaming test\n",
+    );
+    const buildB = runCliBuild(srcB);
+    assert.equal(buildB.status, 0, buildB.stderr);
+    const wikiB = `${srcB}.wiki`;
+
+    const target = join(parent, "joined.wiki");
+    mkdirSync(target, { recursive: true });
+
+    let firstPhaseSignaller;
+    const firstPhasePromise = new Promise((resolve) => {
+      firstPhaseSignaller = resolve;
+    });
+    const observedPhases = [];
+    const joinPromise = runJoin([wikiA, wikiB], target, {
+      qualityMode: "deterministic",
+      idCollisionPolicy: "namespace",
+      onPhase: ({ phase, summary }) => {
+        observedPhases.push(phase);
+        if (phase === "ingest-all") firstPhaseSignaller(phase);
+      },
+    });
+
+    const winner = await Promise.race([
+      firstPhasePromise.then(() => "phase-fired"),
+      joinPromise.then(() => "join-resolved"),
+    ]);
+    assert.equal(
+      winner,
+      "phase-fired",
+      `onPhase("ingest-all") must settle BEFORE runJoin's promise resolves — proves the callback streams during execution rather than batching at end. Observed phases at race time: ${JSON.stringify(observedPhases)}`,
+    );
+
+    // Cleanup: still need to await runJoin's resolution to
+    // avoid an unhandled-promise-rejection warning. The
+    // runJoin invocation runs without an orchestrator-driven
+    // preOpSnapshot, so the target tree never gets the
+    // `.llmwiki/git/` markers `validateWiki` requires — we
+    // expect the call to fail at phase 9 with
+    // `JOIN-TARGET-INVALID`. That's fine: the streaming
+    // contract is already proven by the Promise.race winner
+    // above; the eventual failure is downstream of the part
+    // we're testing. Swallow it.
+    await joinPromise.catch((err) => {
+      if (err.code !== "JOIN-TARGET-INVALID") throw err;
+    });
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
   }
 });

--- a/tests/unit/join.test.mjs
+++ b/tests/unit/join.test.mjs
@@ -32,7 +32,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { renderFrontmatter, parseFrontmatter } from "../../scripts/lib/frontmatter.mjs";
 import {
@@ -48,7 +48,6 @@ import {
   validateSources,
 } from "../../scripts/lib/join.mjs";
 import { spawnSync } from "node:child_process";
-import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 const CLI = join(
   dirname(fileURLToPath(import.meta.url)),


### PR DESCRIPTION
## Summary

Follow-up to PR #17 — addresses 4 Copilot threads that were unresolved when I merged that PR. My GraphQL polling used `first: 40` on `reviewThreads` but the PR had iterated past that limit, so the threads fell in the overflow. (Same workflow bug as PR #18. Going forward, `first: 100` everywhere.)

## Fixes

1. **Join phase breadcrumbs now stream in real time.** Before: `runJoin` recorded phases into a local `phaseLog[]`, and the orchestrator's join branch only relayed them into the outer `phases[]` AFTER `runJoin` returned (`for (const p of result.phases) record(...)`). The CLI's `onProgress` breadcrumb fires via the outer `record()`, so join's per-phase stderr lines all printed at once at the end — a multi-minute join looked like silence followed by a flood.
   - New: `runJoin` accepts an `onPhase({phase, summary})` callback that its internal `record()` invokes the moment each phase fires (synchronously, before the next `await`). Orchestrator's join branch passes a callback that calls the outer `record()` live. Batch-relay loop dropped.
   - `runJoin`'s `phaseLog` still accumulates for the returned-result shape; the outer `phases[]` gets populated during execution rather than at the end.

2. **Strict monotonic phase-index test.** The round-1 `cli-progress` test checked `indices[i] >= indices[i - 1]`, which would pass even if `onProgress` fired twice with the same index — undermining the "one callback per phase" contract. New: every observed index equals `i + 1` (strictly consecutive starting at 1), ruling out both duplicates and gaps.

3. Doc threads about join streaming (guide/cli.md:238, CHANGELOG:26, orchestrator.mjs:95) claimed real-time streaming for join — now TRUE under the fix, so those threads are addressed without doc changes.

## Test plan

- [x] 3 cli-progress tests (strict-monotonic assertion updated)
- [x] 17 join unit tests (onPhase callback shape change is backwards-compatible; existing tests don't pass the callback)
- [x] 4 join e2e tests
- [x] Total: 24 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)