### PR TITLE
fix(cluster-detect): synthesise cluster focus from top-N covers

### DIFF
--- a/scripts/lib/cluster-detect.mjs
+++ b/scripts/lib/cluster-detect.mjs
@@ -963,7 +963,17 @@ export function deterministicPurpose(componentLeaves) {
     return top.length === 1 ? top[0] : top.join("; ");
   }
   const sorted = normalised
-    .map((data) => ({ id: data?.id ?? "", focus: data?.focus ?? "" }))
+    .map((data) => ({
+      id: data?.id ?? "",
+      // Mirror the single-member branch: only accept string focus
+      // values, normalise everything else to "". Without this, a
+      // hand-authored leaf with a non-string `focus:` (e.g. a YAML
+      // number `0` or `false`) would propagate through and make
+      // `deterministicPurpose()` return a non-string, breaking the
+      // documented contract that this helper always returns a
+      // string.
+      focus: typeof data?.focus === "string" ? data.focus : "",
+    }))
     .filter((x) => x.id)
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   return sorted[0]?.focus ?? "";

--- a/scripts/lib/cluster-detect.mjs
+++ b/scripts/lib/cluster-detect.mjs
@@ -906,11 +906,32 @@ export function buildSiblingIdfContext(siblings) {
   return computeIdf(tokenLists);
 }
 
-// Deterministic purpose for the NEST stub's `focus:` field. Picks the
-// single cover phrase that appears in the most member frontmatters
-// (with lex tie-breaking for reproducibility). When members share no
-// covers, falls back to the focus of the member whose id sorts first
-// — still deterministic, still driven by member content alone.
+// Maximum number of cover phrases to splice into a multi-member
+// cluster's synthesised focus. Four is a soft cap that keeps the
+// resulting string short enough to read at a glance while still
+// telling the orchestrator the cluster is multi-topic.
+const PURPOSE_MAX_COVERS = 4;
+
+// Deterministic purpose for the NEST stub's `focus:` field.
+//
+// Tiered policy:
+//   - Single-member cluster: return the member's own `focus` directly
+//     — concise + accurate, e.g. for an X.11 root-containment outlier
+//     whose folder will hold exactly one leaf.
+//   - Multi-member cluster: aggregate the top-N cover phrases across
+//     members ranked by frequency desc, then lex asc, joined with
+//     "; ". This is the corrected behaviour: previously the
+//     algorithm returned just the lex-first highest-count cover,
+//     which on coarse k-means clusters of diverse content (where no
+//     cover appears in multiple members) collapsed to "the
+//     alphabetically-first cover of any member" — producing
+//     misleading single-leaf focus strings on multi-topic clusters
+//     (see X.11 wiki output where an 8-leaf ops/observability
+//     cluster's focus read "Action items without owner or deadline",
+//     which was just one detail of one member).
+//   - Multi-member cluster with no covers anywhere: fall back to the
+//     focus of the member whose id sorts first. Still deterministic,
+//     still driven by member content alone.
 //
 // Accepts either `{ path, data }` leaf wrappers or plain frontmatter
 // objects. Input is normalised via `leaf?.data ?? leaf` at the top so
@@ -919,6 +940,9 @@ export function buildSiblingIdfContext(siblings) {
 // without getting silent empty results for the plain-object path.
 export function deterministicPurpose(componentLeaves) {
   const normalised = componentLeaves.map((leaf) => leaf?.data ?? leaf);
+  if (normalised.length === 1) {
+    return typeof normalised[0]?.focus === "string" ? normalised[0].focus : "";
+  }
   const counts = new Map();
   for (const data of normalised) {
     const covers = Array.isArray(data?.covers) ? data.covers : [];
@@ -935,7 +959,8 @@ export function deterministicPurpose(componentLeaves) {
       if (b[1] !== a[1]) return b[1] - a[1];
       return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
     });
-    return ranked[0][0];
+    const top = ranked.slice(0, PURPOSE_MAX_COVERS).map(([cover]) => cover);
+    return top.length === 1 ? top[0] : top.join("; ");
   }
   const sorted = normalised
     .map((data) => ({ id: data?.id ?? "", focus: data?.focus ?? "" }))

--- a/tests/unit/cluster-detect.test.mjs
+++ b/tests/unit/cluster-detect.test.mjs
@@ -555,6 +555,30 @@ test("deterministicPurpose: falls back to first-sorted-id's focus when no covers
   assert.equal(deterministicPurpose(leaves), "alpha focus text");
 });
 
+test("deterministicPurpose: no-covers fallback always returns a string", () => {
+  // Pin the helper's "always returns a string" contract on the
+  // multi-member no-covers fallback path. Both the single-member
+  // branch and the joined-covers branch already normalise to a
+  // string; this test guards the lex-first-fallback branch from
+  // propagating non-string `focus:` values (e.g. YAML number `0`,
+  // boolean `false`, missing key) — without normalisation those
+  // would flow through `data?.focus ?? ""` (which only catches
+  // null/undefined) and the function's return type would silently
+  // change.
+  const numeric = [
+    { data: { id: "alpha", focus: 0 } },
+    { data: { id: "beta", focus: 42 } },
+  ];
+  assert.strictEqual(deterministicPurpose(numeric), "");
+  const mixed = [
+    { data: { id: "alpha" } },
+    { data: { id: "beta", focus: "real text" } },
+  ];
+  // alpha's missing focus normalises to "" and wins the lex-sort,
+  // so the helper returns "" — still a string, still deterministic.
+  assert.strictEqual(deterministicPurpose(mixed), "");
+});
+
 test("deterministicPurpose: accepts plain frontmatter objects (no wrapper)", () => {
   // API-shape symmetry with generateDeterministicSlug and
   // buildSiblingIdfContext: the helper must normalise either leaf

--- a/tests/unit/cluster-detect.test.mjs
+++ b/tests/unit/cluster-detect.test.mjs
@@ -469,28 +469,85 @@ test("generateDeterministicSlug: hash fallback when no valid token survives", ()
 
 // ─── deterministicPurpose ────────────────────────────────────────────
 
-test("deterministicPurpose: picks the most-shared cover phrase", () => {
+test("deterministicPurpose: shared-cover wins frequency rank, then lex top-up follows", () => {
+  // 3 members. `shared-topic` appears in 2 of them so it ranks first
+  // by frequency. The remaining covers (alpha / beta / gamma) all
+  // appear once and are lex-sorted into the top-up slots so the
+  // resulting focus is honest about the cluster being multi-topic.
   const leaves = [
     { data: { id: "a", focus: "A focus", covers: ["shared-topic", "alpha"] } },
     { data: { id: "b", focus: "B focus", covers: ["shared-topic", "beta"] } },
     { data: { id: "c", focus: "C focus", covers: ["gamma"] } },
   ];
-  assert.equal(deterministicPurpose(leaves), "shared-topic");
+  assert.equal(
+    deterministicPurpose(leaves),
+    "shared-topic; alpha; beta; gamma",
+    "shared-topic ranks first (count 2); the rest fill in count-1 lex order",
+  );
 });
 
-test("deterministicPurpose: lex tie-break on equal frequency", () => {
+test("deterministicPurpose: all-unique covers → top-N lex-sorted union", () => {
+  // No cover is shared across members — the historical bug case
+  // that picked one arbitrary lex-first cover and lied about the
+  // cluster's content. New behaviour joins the union with "; ".
   const leaves = [
     { data: { id: "a", focus: "A focus", covers: ["zzz"] } },
     { data: { id: "b", focus: "B focus", covers: ["aaa"] } },
   ];
   assert.equal(
     deterministicPurpose(leaves),
-    "aaa",
-    "lex-smallest wins tie-break for reproducibility",
+    "aaa; zzz",
+    "no shared covers → top-N (here all) joined in deterministic lex order",
   );
 });
 
+test("deterministicPurpose: caps the joined focus at PURPOSE_MAX_COVERS=4", () => {
+  // 6 members with all-unique covers. Output must include at most
+  // 4 covers so the synthesised focus stays scannable.
+  const leaves = [
+    { data: { id: "a", focus: "fA", covers: ["a-cover"] } },
+    { data: { id: "b", focus: "fB", covers: ["b-cover"] } },
+    { data: { id: "c", focus: "fC", covers: ["c-cover"] } },
+    { data: { id: "d", focus: "fD", covers: ["d-cover"] } },
+    { data: { id: "e", focus: "fE", covers: ["e-cover"] } },
+    { data: { id: "f", focus: "fF", covers: ["f-cover"] } },
+  ];
+  assert.equal(
+    deterministicPurpose(leaves),
+    "a-cover; b-cover; c-cover; d-cover",
+    "top-4 covers joined; later covers dropped to keep focus readable",
+  );
+});
+
+test("deterministicPurpose: single-member cluster returns the member's own focus", () => {
+  // X.11 root-containment moves a single outlier leaf into its own
+  // dedicated folder. The folder's focus must reflect what that one
+  // leaf is actually about — not a multi-cover join, which would be
+  // pointlessly verbose for a 1-leaf cluster.
+  const leaf = {
+    data: {
+      id: "outlier",
+      focus: "Specific outlier topic that has no cluster home",
+      covers: ["topic-a", "topic-b", "topic-c"],
+    },
+  };
+  assert.equal(
+    deterministicPurpose([leaf]),
+    "Specific outlier topic that has no cluster home",
+  );
+});
+
+test("deterministicPurpose: single-member cluster handles empty/missing focus safely", () => {
+  // A leaf with no `focus:` should produce an empty string, not crash.
+  // (Earlier versions of the helper returned `""` via the `?? ""` at
+  // the bottom; preserve that contract.)
+  assert.equal(deterministicPurpose([{ data: { id: "a" } }]), "");
+  assert.equal(deterministicPurpose([{ data: { id: "a", focus: 0 } }]), "");
+});
+
 test("deterministicPurpose: falls back to first-sorted-id's focus when no covers", () => {
+  // ≥ 2 members and no covers anywhere → deterministic lex-first
+  // fallback. Preserves the historical contract for this edge case.
   const leaves = [
     { data: { id: "beta", focus: "beta focus text" } },
     { data: { id: "alpha", focus: "alpha focus text" } },
@@ -511,11 +568,12 @@ test("deterministicPurpose: accepts plain frontmatter objects (no wrapper)", () 
     { id: "b", focus: "B focus", covers: ["shared-topic", "beta"] },
     { id: "c", focus: "C focus", covers: ["gamma"] },
   ];
-  assert.equal(deterministicPurpose(plain), "shared-topic");
+  const expected = "shared-topic; alpha; beta; gamma";
+  assert.equal(deterministicPurpose(plain), expected);
   // Control: the same inputs wrapped in `{ data }` must produce the
   // same result, proving the normalisation is semantically lossless.
   const wrapped = plain.map((data) => ({ data }));
-  assert.equal(deterministicPurpose(wrapped), "shared-topic");
+  assert.equal(deterministicPurpose(wrapped), expected);
 });
 
 // ── detectCoarseClusters (Phase X.10 — flat large-diverse root pre-pass) ─


### PR DESCRIPTION
## Summary

- Fix `deterministicPurpose()` so multi-member clusters get a synthesised, multi-cover focus string instead of a misleading single-leaf phrase.
- Single-member clusters return the member's own focus directly (X.11 root-containment outlier case stays clean).
- Output is still a single string, still byte-reproducible, still zero Tier 2 — just honest about multi-topic clusters.

## Why

Previously `deterministicPurpose()` picked the lex-first highest-count cover phrase as the cluster's `focus:` field. On coarse k-means clusters of diverse content (where no cover appears in multiple members), this collapsed to "the alphabetically-first cover of any member" — producing misleading single-leaf focus strings on multi-topic clusters.

Concrete failure observed in skill-code-review's `reviewers.wiki/` (X.6 + X.11 build): an 8-leaf ops/observability cluster grouping SOC2 / backup-DR / incident-response / alerting / metrics / chaos-engineering / graceful-degradation / error-tracking ended up with focus `"Action items without owner or deadline"` — just one detail of one of its members. A semantic router walking the wiki tree would reasonably skip such a cluster when looking for routing matches outside that one detail. This blocks Phase 3 of the dependent skill-code-review rewiring (orchestrator routes off `reviewers.wiki/index.md`'s `focus` strings).

## New tiered policy

- **Single-member cluster** → return the member's own focus directly (X.11 root-containment outlier case). Concise + accurate.
- **Multi-member with shared covers (count ≥ 2)** → top-N covers ranked by frequency desc, then lex asc, joined with `"; "`.
- **Multi-member with all-unique covers** → top-N from the full union (all count=1, deterministic lex order), joined.
- **Multi-member with no covers anywhere** → lex-first member's focus (preserved historical fallback).

`PURPOSE_MAX_COVERS=4` keeps the synthesised focus scannable.

## Test plan

- [x] 4 existing `deterministicPurpose` test cases updated to reflect the new joining behaviour
- [x] 3 new test cases added: single-member returns own focus, top-N cap at 4, missing-focus safety
- [x] 35/35 cluster-detect unit tests pass
- [x] Full unit suite: 619/619
- [x] Full e2e suite: 718/721 (3 pre-existing skips)
- [ ] Synthetic-fixture build to eyeball the new focus strings end-to-end
- [ ] Rebuild `skill-code-review/reviewers.wiki/` and confirm cluster focuses are now meaningful for orchestrator routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)