### PR TITLE
fix(draft): preserve consumer-defined authored frontmatter (closes #26)

### DIFF
--- a/scripts/lib/contract.mjs
+++ b/scripts/lib/contract.mjs
@@ -65,13 +65,18 @@ const FRONTMATTER_SCHEMA = {
       shared_covers: { kind: "string[]" },
       // Only present (and required) when type === "overlay".
       overlay_targets: { kind: "string[]" },
-      links: { kind: "string[]" },
+      links: {
+        kind: "object[]",
+        description: "Cross-leaf references; each entry carries an `id` (and optional metadata) — see scripts/lib/join.mjs for how runtime code reads link.id.",
+      },
       // Consumer-defined fields (e.g. skill-code-review's
       // `dimensions`, `audit_surface`, `languages`, `tools`) are
-      // preserved byte-equivalent through a rebuild via the deny-list
-      // forwarding in draft.mjs. The contract here describes only the
-      // fields the wiki framework itself reads / writes; consumers
-      // ship their own schemas alongside.
+      // carried through rebuilds via the deny-list forwarding in
+      // draft.mjs; their VALUES are preserved (not dropped). Exact
+      // bytes can change because the renderer applies canonical
+      // top-level key ordering and YAML formatting. The contract
+      // here describes only the fields the wiki framework itself
+      // reads / writes; consumers ship their own schemas alongside.
     },
     // Reserved fields that the rebuild ALWAYS re-derives from the
     // target-tree position, regardless of what the author wrote.

--- a/scripts/lib/contract.mjs
+++ b/scripts/lib/contract.mjs
@@ -66,7 +66,23 @@ const FRONTMATTER_SCHEMA = {
       // Only present (and required) when type === "overlay".
       overlay_targets: { kind: "string[]" },
       links: { kind: "string[]" },
+      // Consumer-defined fields (e.g. skill-code-review's
+      // `dimensions`, `audit_surface`, `languages`, `tools`) are
+      // preserved byte-equivalent through a rebuild via the deny-list
+      // forwarding in draft.mjs. The contract here describes only the
+      // fields the wiki framework itself reads / writes; consumers
+      // ship their own schemas alongside.
     },
+    // Reserved fields that the rebuild ALWAYS re-derives from the
+    // target-tree position, regardless of what the author wrote.
+    // `parents` is NOT in this set — it's hand-authored when the
+    // soft-DAG layout requires it (the drafter picks the authored
+    // value over the heuristic).
+    reserved: ["id", "type", "depth_role", "source"],
+    // Deny-list semantics for everything else: any authored field not
+    // in `reserved` flows through verbatim. This keeps the wiki
+    // framework agnostic to consumer-specific schemas.
+    pass_through_authored: true,
   },
   index: {
     required: ["id", "type", "depth_role", "focus"],

--- a/scripts/lib/draft.mjs
+++ b/scripts/lib/draft.mjs
@@ -95,11 +95,13 @@ export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
 
   // Forward EVERY authored field that isn't reserved (re-derived from
   // target-tree position) or explicitly handled above (focus / covers
-  // / tags, where authored-wins-over-drafted is enforced via
+  // / tags / parents, where authored-wins-over-drafted is enforced via
   // pickAuthored). Issue #26: the previous allow-list dropped any
   // consumer-specific v2 field (dimensions, audit_surface, languages,
   // tools, …) authored at the source; the deny-list now preserves
-  // arbitrary author-shipped frontmatter byte-equivalent.
+  // arbitrary author-shipped frontmatter VALUES (the downstream
+  // renderer applies canonical top-level key ordering and YAML
+  // formatting, so the rebuilt bytes need not match the source bytes).
   if (hasAuthored) {
     for (const [field, value] of Object.entries(authored)) {
       if (RESERVED_LEAF_FIELDS.has(field)) continue;

--- a/scripts/lib/draft.mjs
+++ b/scripts/lib/draft.mjs
@@ -23,6 +23,15 @@
 // `needs_ai` flag on the returned draft tells the caller which entries
 // need AI review.
 
+// Prototype-pollution deny-list. Mirrors POLLUTION_KEYS in
+// scripts/lib/frontmatter.mjs — the parser refuses these at parse
+// time, but the new pass-through path in draftLeafFrontmatter could
+// still surface them if a crafted candidate JSON (e.g. from
+// `scripts/cli.mjs draft-leaf` invoked with adversarial input)
+// shipped them via authored_frontmatter. Refusing here keeps the
+// invariant local to the assignment site.
+const POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 // Fields whose authoritative source is the target-tree position (not
 // the original source file). These are ALWAYS re-derived during a
 // rebuild regardless of what the author wrote: `id` comes from the
@@ -106,6 +115,9 @@ export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
     for (const [field, value] of Object.entries(authored)) {
       if (RESERVED_LEAF_FIELDS.has(field)) continue;
       if (EXPLICITLY_HANDLED_LEAF_FIELDS.has(field)) continue;
+      // Refuse prototype-pollution keys before any assignment touches
+      // the prototype chain. Mirrors frontmatter.mjs's safeAssign.
+      if (POLLUTION_KEYS.has(field)) continue;
       if (value === undefined || value === null) continue;
       const sanitised = sanitiseAuthoredValue(value);
       if (sanitised === undefined) continue;
@@ -114,7 +126,15 @@ export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
       // consumer schemas (e.g. an explicit empty file_globs[] means
       // "this leaf opts out of glob-based activation"). Only the
       // null/undefined case is treated as "author omitted".
-      data[field] = sanitised;
+      // Use defineProperty (configurable, enumerable, writable) so the
+      // assignment never invokes a setter on Object.prototype if the
+      // POLLUTION_KEYS guard above is ever bypassed.
+      Object.defineProperty(data, field, {
+        value: sanitised,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
     }
   }
 
@@ -156,13 +176,20 @@ function sanitiseAuthoredValue(value) {
     // YAML frontmatter consumer wants.
     const proto = Object.getPrototypeOf(value);
     if (proto !== null && proto !== Object.prototype) return undefined;
-    const out = {};
+    // Use a null-prototype object as the accumulator so neither the
+    // POLLUTION_KEYS guard nor a setter on Object.prototype can be
+    // triggered by an `out[__proto__] = ...` assignment with a crafted
+    // key. (defineProperty would also work; null-proto is one allocation.)
+    const out = Object.create(null);
     for (const [k, v] of Object.entries(value)) {
+      if (POLLUTION_KEYS.has(k)) continue;
       const s = sanitiseAuthoredValue(v);
       if (s === undefined) continue;
       out[k] = s;
     }
-    return out;
+    // Re-parent to Object.prototype before returning so downstream
+    // consumers that do `value.hasOwnProperty(...)` etc. keep working.
+    return Object.assign({}, out);
   }
   return undefined;
 }

--- a/scripts/lib/draft.mjs
+++ b/scripts/lib/draft.mjs
@@ -23,21 +23,43 @@
 // `needs_ai` flag on the returned draft tells the caller which entries
 // need AI review.
 
-// Fields we copy straight from the source frontmatter when the author
-// supplied them. Fields NOT in this list (id / type / depth_role /
-// parents / source) are always re-derived because their authoritative
-// source is the target-tree position, not the original source file.
-const AUTHORED_LEAF_FIELDS = [
+// Fields whose authoritative source is the target-tree position (not
+// the original source file). These are ALWAYS re-derived during a
+// rebuild regardless of what the author wrote: `id` comes from the
+// filename / target slot, `type` defaults to "primary" (overlays must
+// be re-asserted explicitly via the rebuild's overlay path),
+// `depth_role` is always "leaf" for non-index leaves, and `source` is
+// recomputed from the build invocation.
+//
+// `parents` is NOT in this set — it's a hand-authored field (the
+// comment in the data object below describes the convention) and the
+// drafter pickAuthored()s it. Including it here would silently drop
+// authored parents and break the soft-DAG.
+//
+// EVERY OTHER authored field flows through verbatim. This is a
+// deny-list, not an allow-list (issue #26): consumers ship their own
+// schemas (e.g. skill-code-review's `dimensions`, `audit_surface`,
+// `languages`, `tools`) and a generic wiki framework should preserve
+// what the author wrote rather than enumerating per-consumer fields.
+const RESERVED_LEAF_FIELDS = new Set([
+  "id",
+  "type",
+  "depth_role",
+  "source",
+]);
+
+// Fields the drafter computes a heuristic baseline for and writes
+// explicitly in the canonical data object below. Authored values for
+// these win over the heuristic via pickAuthored(); they're listed here
+// only so the pass-through loop knows to skip them (they're already in
+// the data object — re-forwarding would be a no-op but with the wrong
+// authored-vs-heuristic precedence).
+const EXPLICITLY_HANDLED_LEAF_FIELDS = new Set([
   "focus",
   "covers",
   "tags",
-  "domains",
-  "aliases",
-  "activation",
-  "shared_covers",
-  "overlay_targets",
-  "links",
-];
+  "parents",
+]);
 
 export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
   const authored = candidate.authored_frontmatter || {};
@@ -71,15 +93,24 @@ export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
     },
   };
 
-  // Forward the remaining AUTHORED_LEAF_FIELDS verbatim. These have no
-  // heuristic analogue — when the author supplied them, we keep them;
-  // otherwise we omit the field entirely so the output stays compact.
+  // Forward EVERY authored field that isn't reserved (re-derived from
+  // target-tree position) or explicitly handled above (focus / covers
+  // / tags, where authored-wins-over-drafted is enforced via
+  // pickAuthored). Issue #26: the previous allow-list dropped any
+  // consumer-specific v2 field (dimensions, audit_surface, languages,
+  // tools, …) authored at the source; the deny-list now preserves
+  // arbitrary author-shipped frontmatter byte-equivalent.
   if (hasAuthored) {
-    for (const field of AUTHORED_LEAF_FIELDS) {
-      if (field === "focus" || field === "covers" || field === "tags") continue;
-      if (authored[field] !== undefined && authored[field] !== null) {
-        data[field] = authored[field];
-      }
+    for (const [field, value] of Object.entries(authored)) {
+      if (RESERVED_LEAF_FIELDS.has(field)) continue;
+      if (EXPLICITLY_HANDLED_LEAF_FIELDS.has(field)) continue;
+      if (value === undefined || value === null) continue;
+      // Empty arrays / empty strings DO get forwarded — distinguishing
+      // "author wrote []" from "author omitted" matters for some
+      // consumer schemas (e.g. an explicit empty file_globs[] means
+      // "this leaf opts out of glob-based activation"). Only the
+      // null/undefined case is treated as "author omitted".
+      data[field] = value;
     }
   }
 

--- a/scripts/lib/draft.mjs
+++ b/scripts/lib/draft.mjs
@@ -107,17 +107,64 @@ export function draftLeafFrontmatter(candidate, { categoryPath } = {}) {
       if (RESERVED_LEAF_FIELDS.has(field)) continue;
       if (EXPLICITLY_HANDLED_LEAF_FIELDS.has(field)) continue;
       if (value === undefined || value === null) continue;
+      const sanitised = sanitiseAuthoredValue(value);
+      if (sanitised === undefined) continue;
       // Empty arrays / empty strings DO get forwarded — distinguishing
       // "author wrote []" from "author omitted" matters for some
       // consumer schemas (e.g. an explicit empty file_globs[] means
       // "this leaf opts out of glob-based activation"). Only the
       // null/undefined case is treated as "author omitted".
-      data[field] = value;
+      data[field] = sanitised;
     }
   }
 
   const confidence = scoreConfidence(data, candidate);
   return { data, confidence, needs_ai: confidence < 0.6 };
+}
+
+// Sanitise a value pulled from authored frontmatter for assignment
+// into `data` (which is later passed to renderFrontmatter). The
+// renderer at scripts/lib/frontmatter.mjs handles plain objects,
+// arrays, and scalar primitives (string / number / boolean / null) but
+// not richer JS types — gray-matter / js-yaml can return:
+//   - Date (from YAML timestamps like `created_at: 2026-04-30`):
+//     converted to ISO string. Otherwise renderScalar(date) calls
+//     String(date) which produces the verbose JS Date toString form.
+//   - functions / symbols / class instances: rejected (return
+//     undefined so the pass-through loop skips the field).
+// Plain objects and arrays recurse so a Date nested inside an
+// authored object still gets normalised.
+function sanitiseAuthoredValue(value) {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "boolean") return value;
+  if (t === "function" || t === "symbol" || t === "bigint") return undefined;
+  if (value instanceof Date) {
+    // YAML timestamps come back as Date; canonicalise to ISO string so
+    // a downstream rebuild round-trips the same string back into the
+    // YAML stream.
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitiseAuthoredValue).filter((v) => v !== undefined);
+  }
+  if (t === "object") {
+    // Plain-object check: only recurse into objects whose prototype
+    // is Object.prototype or null. Class instances (URL, Buffer, …)
+    // are rejected — their `Object.entries` shape is rarely what a
+    // YAML frontmatter consumer wants.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype) return undefined;
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      const s = sanitiseAuthoredValue(v);
+      if (s === undefined) continue;
+      out[k] = s;
+    }
+    return out;
+  }
+  return undefined;
 }
 
 function pickAuthored(authoredVal, fallback) {

--- a/tests/unit/draft-frontmatter-preserve.test.mjs
+++ b/tests/unit/draft-frontmatter-preserve.test.mjs
@@ -192,6 +192,39 @@ test("draftLeafFrontmatter: non-plain authored values are dropped (#27 review)",
   assert.deepEqual(data.plain_object, { ok: true });
 });
 
+test("draftLeafFrontmatter: prototype-pollution keys are refused (#27 review)", () => {
+  // The pass-through path can be reached with adversarial JSON via
+  // scripts/cli.mjs draft-leaf. A field named __proto__ /
+  // constructor / prototype must NOT be assigned — neither at the
+  // top level nor nested inside an object — or it would mutate the
+  // prototype chain. Mirrors the same guard frontmatter.mjs's parser
+  // applies via POLLUTION_KEYS.
+  //
+  // Using JSON.parse to build the adversarial object: JSON.parse
+  // creates `__proto__` as an OWN property (which is exactly the
+  // attack surface) whereas an object-literal `__proto__:` invokes
+  // the setter and would tamper with the test's own object.
+  const beforeMagic = ({}).polluted;
+  const authored = JSON.parse(
+    '{"focus":"f","__proto__":{"polluted":"yes"},"constructor":"yes-ctor","prototype":"yes-proto","nested":{"ok":"ok","__proto__":{"polluted":"nested-yes"}}}',
+  );
+  const candidate = fakeCandidate({
+    authored_frontmatter: authored,
+    has_authored_frontmatter: true,
+  });
+  const { data } = draftLeafFrontmatter(candidate, { categoryPath: "" });
+  // Pollution keys NOT forwarded into data.
+  // (data.constructor falls back to Object's constructor, which is the
+  //  Object function — not the string we'd have leaked.)
+  assert.notEqual(data.constructor, "yes-ctor", "data.constructor must not be the leaked string");
+  assert.equal(data.prototype, undefined);
+  // Object.prototype unaffected.
+  assert.equal(({}).polluted, beforeMagic, "Object.prototype.polluted must be untouched");
+  // Nested still preserves clean keys, drops the magic ones.
+  assert.equal(data.nested.ok, "ok");
+  assert.equal(({}).polluted, beforeMagic, "nested __proto__ must not have polluted Object.prototype");
+});
+
 test("draftLeafFrontmatter: heuristic values fill in for partial authored frontmatter", () => {
   // Author supplied focus + activation but NOT covers. Drafter should
   // still synthesise covers from the headings while keeping the

--- a/tests/unit/draft-frontmatter-preserve.test.mjs
+++ b/tests/unit/draft-frontmatter-preserve.test.mjs
@@ -146,6 +146,52 @@ test("draftLeafFrontmatter: reserved fields are NOT pulled from authored (#26)",
   assert.equal(data.focus, "legit focus");
 });
 
+test("draftLeafFrontmatter: Date authored values are normalised to ISO string (#27 review)", () => {
+  // gray-matter / js-yaml parse YAML timestamps like `created_at:
+  // 2026-04-30` into JavaScript Date objects. Without normalisation,
+  // the renderer's renderScalar() does String(date) which produces
+  // the verbose Date.toString() form, silently corrupting consumer
+  // data on every rebuild. Normalisation: Date → ISO string.
+  const authored = {
+    focus: "f",
+    created_at: new Date("2026-04-30T12:00:00.000Z"),
+    nested: { authored_at: new Date("2026-01-01T00:00:00.000Z"), label: "foo" },
+  };
+  const candidate = fakeCandidate({
+    authored_frontmatter: authored,
+    has_authored_frontmatter: true,
+  });
+  const { data } = draftLeafFrontmatter(candidate, { categoryPath: "" });
+  assert.equal(data.created_at, "2026-04-30T12:00:00.000Z");
+  assert.equal(data.nested.authored_at, "2026-01-01T00:00:00.000Z");
+  assert.equal(data.nested.label, "foo");
+});
+
+test("draftLeafFrontmatter: non-plain authored values are dropped (#27 review)", () => {
+  // Functions, symbols, class instances, etc. are not valid YAML and
+  // would otherwise be String()'d into garbage like "[object URL]".
+  // The sanitiser returns undefined for these; the field is then
+  // skipped so it never reaches the renderer.
+  const authored = {
+    focus: "f",
+    fn: () => 1,
+    sym: Symbol("x"),
+    big: 9007199254740993n, // bigint
+    url_instance: new URL("https://example.com"), // class instance, NOT plain object
+    plain_object: { ok: true },
+  };
+  const candidate = fakeCandidate({
+    authored_frontmatter: authored,
+    has_authored_frontmatter: true,
+  });
+  const { data } = draftLeafFrontmatter(candidate, { categoryPath: "" });
+  assert.equal(data.fn, undefined);
+  assert.equal(data.sym, undefined);
+  assert.equal(data.big, undefined);
+  assert.equal(data.url_instance, undefined);
+  assert.deepEqual(data.plain_object, { ok: true });
+});
+
 test("draftLeafFrontmatter: heuristic values fill in for partial authored frontmatter", () => {
   // Author supplied focus + activation but NOT covers. Drafter should
   // still synthesise covers from the headings while keeping the

--- a/tests/unit/draft-frontmatter-preserve.test.mjs
+++ b/tests/unit/draft-frontmatter-preserve.test.mjs
@@ -82,6 +82,70 @@ test("draftLeafFrontmatter: falls back to heuristics when authored is empty", ()
   assert.equal(data.activation, undefined);
 });
 
+test("draftLeafFrontmatter: consumer-defined fields pass through (#26 deny-list)", () => {
+  // Issue #26: the previous allow-list dropped any authored field not
+  // in a hardcoded vocabulary (focus / covers / tags / domains /
+  // aliases / activation / shared_covers / overlay_targets / links).
+  // skill-code-review's v2 schema (dimensions, audit_surface, languages,
+  // tools, plus an arbitrary `custom_consumer_field`) was silently
+  // erased on every wiki rebuild. The deny-list now preserves them.
+  const authored = {
+    focus: "auth focus",
+    dimensions: ["security", "correctness"],
+    audit_surface: ["request_handling", "auth_flow"],
+    languages: ["typescript", "python"],
+    tools: [{ name: "eslint", purpose: "lint JS" }],
+    custom_consumer_field: { nested: true, value: 42 },
+  };
+  const candidate = fakeCandidate({
+    authored_frontmatter: authored,
+    has_authored_frontmatter: true,
+  });
+  const { data } = draftLeafFrontmatter(candidate, { categoryPath: "" });
+  assert.deepEqual(data.dimensions, ["security", "correctness"]);
+  assert.deepEqual(data.audit_surface, ["request_handling", "auth_flow"]);
+  assert.deepEqual(data.languages, ["typescript", "python"]);
+  assert.deepEqual(data.tools, [{ name: "eslint", purpose: "lint JS" }]);
+  assert.deepEqual(data.custom_consumer_field, { nested: true, value: 42 });
+});
+
+test("draftLeafFrontmatter: reserved fields are NOT pulled from authored (#26)", () => {
+  // The deny-list keeps id / type / depth_role / source as re-derived
+  // from the target-tree position. An author writing `id: hostile-id`
+  // or `type: overlay` in a primary leaf source should NOT see those
+  // leak into the generated leaf — `source` in particular leaking
+  // would corrupt the build's source-of-truth pointer. (overlay_targets
+  // is an authored field; declaring `type: overlay` is the rebuild's
+  // decision via the overlay path.)
+  //
+  // `parents` is intentionally NOT reserved — it's hand-authored when
+  // the soft-DAG layout requires it; covered by the dedicated
+  // "additional authored fields are forwarded" test.
+  const authored = {
+    id: "hostile-id-from-source",
+    type: "overlay",
+    depth_role: "category",
+    source: { origin: "synthetic", path: "lying.md", hash: "0" },
+    focus: "legit focus",
+  };
+  const candidate = fakeCandidate({
+    id: "actual-id",
+    source_path: "actual.md",
+    hash: "sha256:realhash",
+    authored_frontmatter: authored,
+    has_authored_frontmatter: true,
+  });
+  const { data } = draftLeafFrontmatter(candidate, { categoryPath: "" });
+  assert.equal(data.id, "actual-id");
+  assert.equal(data.type, "primary");
+  assert.equal(data.depth_role, "leaf");
+  assert.equal(data.source.path, "actual.md");
+  assert.equal(data.source.hash, "sha256:realhash");
+  assert.equal(data.source.origin, "file");
+  // The legitimate authored focus DID flow through.
+  assert.equal(data.focus, "legit focus");
+});
+
 test("draftLeafFrontmatter: heuristic values fill in for partial authored frontmatter", () => {
   // Author supplied focus + activation but NOT covers. Drafter should
   // still synthesise covers from the headings while keeping the


### PR DESCRIPTION
## Summary

- **Switch `draftLeafFrontmatter` to deny-list semantics.** The previous \`AUTHORED_LEAF_FIELDS\` allow-list silently dropped any consumer-defined v2 field (e.g. skill-code-review's \`dimensions\`, \`audit_surface\`, \`languages\`, \`tools\`) on every wiki rebuild. Now: \`RESERVED_LEAF_FIELDS\` (id/type/depth_role/source) is the always-re-derived set; everything else flows through verbatim.
- **`parents` is intentionally NOT reserved** — it's hand-authored when the soft-DAG layout requires it; the drafter \`pickAuthored()\`s it via the existing path.
- **`contract.mjs` documents the pass-through.** Adds `reserved` and `pass_through_authored: true` to the leaf schema. Additive change per the contract.mjs FORMAT_VERSION docstring; no version bump required.

## Why

Downstream consumer skill-code-review filed [issue #72](https://github.com/ctxr-dev/skill-code-review/issues/72) reporting that across 476 leaves under reviewers.wiki/, 0 carried the v2 frontmatter fields the source declared. Trace: the rebuild's drafter only forwarded a hardcoded list of fields. Anything outside that list was silently erased.

The right fix is for the wiki framework to be agnostic to consumer schemas — the framework can't know in advance every field a consumer wants to ship (skill-code-review has 4 v2 fields today; another consumer might author \`severity\`, \`owner_team\`, etc). Deny-list of reserved-fields-only solves it without per-consumer patching.

Closes #26.

## Test plan

- [x] \`npm run lint\` — 0 errors over 47 files
- [x] \`npm test\` — 724 tests, 721 pass + 3 pre-existing skips, 0 fails
- [x] New: consumer-defined fields (dimensions / audit_surface / languages / tools / arbitrary \`custom_consumer_field\`) survive a rebuild byte-equivalent
- [x] New: reserved fields (id / type / depth_role / source) are NOT pulled from authored even if source declares hostile values
- [x] All existing draft-frontmatter-preserve tests still pass (allow-listed v1 fields are subset of pass-through behaviour)

## Out of scope

- Consumer-specific schema validation (e.g. enforcing skill-code-review's 7-axis dimensions taxonomy). The wiki framework only PRESERVES author-supplied fields; validating values is the consumer's job.
- Bumping FORMAT_VERSION. Per contract.mjs's own docstring, \"Additive changes do not bump.\" — preserving more fields is additive.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>