### PR TITLE
fix(frontmatter): parse block scalars with chomping/indent indicators

### DIFF
--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -128,7 +128,7 @@ function parseMap(p, baseIndent) {
 
     const blockHeader = blockScalarHeader(rest);
     if (blockHeader) {
-      safeAssign(out, key, parseBlockScalar(p, baseIndent, blockHeader.literal), p, tok);
+      safeAssign(out, key, parseBlockScalar(p, baseIndent, blockHeader), p, tok);
       continue;
     }
     if (rest !== "") {
@@ -181,7 +181,7 @@ function parseSeq(p, baseIndent) {
 
     const itemBlockHeader = blockScalarHeader(afterDash);
     if (itemBlockHeader) {
-      out.push(parseBlockScalar(p, baseIndent, itemBlockHeader.literal));
+      out.push(parseBlockScalar(p, baseIndent, itemBlockHeader));
       continue;
     }
 
@@ -198,7 +198,7 @@ function parseSeq(p, baseIndent) {
 
     const firstBlockHeader = blockScalarHeader(firstRest);
     if (firstBlockHeader) {
-      item[firstKey] = parseBlockScalar(p, baseIndent + 2, firstBlockHeader.literal);
+      item[firstKey] = parseBlockScalar(p, baseIndent + 2, firstBlockHeader);
     } else if (firstRest !== "") {
       item[firstKey] = parseScalarInline(firstRest);
     } else {
@@ -245,10 +245,13 @@ function parseSeq(p, baseIndent) {
         } else {
           item[subKey] = null;
         }
-      } else if (blockScalarHeader(subRest)) {
-        item[subKey] = parseBlockScalar(p, baseIndent + 2, blockScalarHeader(subRest).literal);
       } else {
-        item[subKey] = parseScalarInline(subRest);
+        const subBlockHeader = blockScalarHeader(subRest);
+        if (subBlockHeader) {
+          item[subKey] = parseBlockScalar(p, baseIndent + 2, subBlockHeader);
+        } else {
+          item[subKey] = parseScalarInline(subRest);
+        }
       }
     }
 
@@ -266,12 +269,19 @@ function parseSeq(p, baseIndent) {
 // is why a serializer-folded `id: >-` (js-yaml's default line wrap) parses
 // instead of tripping "unexpected indent".
 function blockScalarHeader(rest) {
-  const m = /^([|>])(?:([+-])([1-9])?|([1-9])([+-])?)?$/.exec(rest);
-  return m ? { literal: m[1] === "|" } : null;
+  const m = /^([|>])(?:(?:([+-])([1-9])?)|(?:([1-9])([+-])?))?$/.exec(rest);
+  return m
+    ? {
+        literal: m[1] === "|",
+        indent: Number(m[3] ?? m[4] ?? 0),
+      }
+    : null;
 }
 
-function parseBlockScalar(p, baseIndent, literal) {
+function parseBlockScalar(p, baseIndent, header) {
+  const { literal, indent } = header;
   const collected = [];
+  let contentIndent = indent > 0 ? baseIndent + indent : null;
   while (p.pos < p.lines.length) {
     const raw = p.lines[p.pos];
     if (raw.trim() === "") {
@@ -281,7 +291,11 @@ function parseBlockScalar(p, baseIndent, literal) {
     }
     const indent = raw.length - raw.trimStart().length;
     if (indent <= baseIndent) break;
-    collected.push(raw.slice(baseIndent + 2));
+    if (contentIndent == null) {
+      contentIndent = indent;
+    }
+    if (indent < contentIndent) break;
+    collected.push(raw.slice(contentIndent));
     p.pos++;
   }
   // Trim trailing empty lines

--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -126,8 +126,9 @@ function parseMap(p, baseIndent) {
     const rest = text.slice(colon + 1).trim();
     p.advance();
 
-    if (rest === "|" || rest === ">") {
-      safeAssign(out, key, parseBlockScalar(p, baseIndent, rest === "|"), p, tok);
+    const blockHeader = blockScalarHeader(rest);
+    if (blockHeader) {
+      safeAssign(out, key, parseBlockScalar(p, baseIndent, blockHeader.literal), p, tok);
       continue;
     }
     if (rest !== "") {
@@ -178,6 +179,12 @@ function parseSeq(p, baseIndent) {
       continue;
     }
 
+    const itemBlockHeader = blockScalarHeader(afterDash);
+    if (itemBlockHeader) {
+      out.push(parseBlockScalar(p, baseIndent, itemBlockHeader.literal));
+      continue;
+    }
+
     const colon = findKeyColon(afterDash);
     if (colon === -1) {
       out.push(parseScalarInline(afterDash));
@@ -189,8 +196,9 @@ function parseSeq(p, baseIndent) {
     const firstRest = afterDash.slice(colon + 1).trim();
     const item = {};
 
-    if (firstRest === "|" || firstRest === ">") {
-      item[firstKey] = parseBlockScalar(p, baseIndent + 2, firstRest === "|");
+    const firstBlockHeader = blockScalarHeader(firstRest);
+    if (firstBlockHeader) {
+      item[firstKey] = parseBlockScalar(p, baseIndent + 2, firstBlockHeader.literal);
     } else if (firstRest !== "") {
       item[firstKey] = parseScalarInline(firstRest);
     } else {
@@ -237,8 +245,8 @@ function parseSeq(p, baseIndent) {
         } else {
           item[subKey] = null;
         }
-      } else if (subRest === "|" || subRest === ">") {
-        item[subKey] = parseBlockScalar(p, baseIndent + 2, subRest === "|");
+      } else if (blockScalarHeader(subRest)) {
+        item[subKey] = parseBlockScalar(p, baseIndent + 2, blockScalarHeader(subRest).literal);
       } else {
         item[subKey] = parseScalarInline(subRest);
       }
@@ -246,6 +254,20 @@ function parseSeq(p, baseIndent) {
 
     out.push(item);
   }
+}
+
+// Recognise a YAML block scalar header: `|` (literal) or `>` (folded),
+// each optionally carrying a chomping indicator (`+`/`-`) and/or an explicit
+// indentation indicator (a single digit 1-9), in either order (YAML 1.2
+// §8.1.1). Returns { literal } or null. Chomping/indent indicators affect
+// only trailing-newline and indent-detection nuances that do not change the
+// value of the single-line/wrapped scalars our frontmatter uses, so we read
+// them for tolerance but act only on the literal-vs-folded distinction. This
+// is why a serializer-folded `id: >-` (js-yaml's default line wrap) parses
+// instead of tripping "unexpected indent".
+function blockScalarHeader(rest) {
+  const m = /^([|>])(?:([+-])([1-9])?|([1-9])([+-])?)?$/.exec(rest);
+  return m ? { literal: m[1] === "|" } : null;
 }
 
 function parseBlockScalar(p, baseIndent, literal) {

--- a/tests/unit/frontmatter-block-scalar.test.mjs
+++ b/tests/unit/frontmatter-block-scalar.test.mjs
@@ -61,10 +61,13 @@ test("frontmatter: folded scalar as a bare sequence item (- >-)", () => {
   ]);
 });
 
-test("frontmatter: explicit indentation indicator (>2) is recognised", () => {
-  const raw = "---\nfocus: >2\n  wrapped value\n---\nbody\n";
-  const { data } = parseFrontmatter(raw, "<mem>");
-  assert.equal(data.focus, "wrapped value");
+test("frontmatter: explicit indentation indicator is respected", () => {
+  const one = parseFrontmatter("---\nfocus: >1\n wrapped value\n---\nbody\n", "<mem>").data;
+  assert.equal(one.focus, "wrapped value");
+  const two = parseFrontmatter("---\nfocus: >2\n  wrapped value\n---\nbody\n", "<mem>").data;
+  assert.equal(two.focus, "wrapped value");
+  const three = parseFrontmatter("---\nfocus: >3\n   wrapped value\n---\nbody\n", "<mem>").data;
+  assert.equal(three.focus, "wrapped value");
 });
 
 test("frontmatter: bare | and > headers still parse (no regression)", () => {

--- a/tests/unit/frontmatter-block-scalar.test.mjs
+++ b/tests/unit/frontmatter-block-scalar.test.mjs
@@ -1,0 +1,75 @@
+// frontmatter-block-scalar.test.mjs — regression for the line-based parser
+// silently dropping docs whose frontmatter uses a YAML block scalar header
+// carrying a chomping or indentation indicator (`>-`, `|-`, `>2`, ...).
+//
+// A serializer (js-yaml via gray-matter) folds long scalars to `>-` once a
+// value exceeds the default ~80-col line width. The parser previously matched
+// only the bare `|`/`>` headers, so `>-` was read as the literal string ">-"
+// and the indented continuation line tripped "unexpected indent" — excluding
+// the whole doc from index-rebuild and failing validate. These tests pin that
+// every chomping/indent variant routes through the block-scalar reader.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatter } from "../../scripts/lib/frontmatter.mjs";
+
+test("frontmatter: folded scalar with strip chomping (>-) is read, not dropped", () => {
+  const raw = [
+    "---",
+    "id: >-",
+    "  lesson-proactively-invoke-available-skills-for-the-task-frontend-ex-2026-05-23-172853332",
+    "type: primary",
+    "focus: >-",
+    "  Proactively invoke available skills for the task (frontend-excellence,",
+    "  frontend-design)",
+    "---",
+    "body",
+    "",
+  ].join("\n");
+  const { data } = parseFrontmatter(raw, "<mem>");
+  assert.equal(
+    data.id,
+    "lesson-proactively-invoke-available-skills-for-the-task-frontend-ex-2026-05-23-172853332",
+  );
+  assert.equal(data.type, "primary");
+  assert.equal(
+    data.focus,
+    "Proactively invoke available skills for the task (frontend-excellence, frontend-design)",
+  );
+});
+
+test("frontmatter: literal scalar with strip chomping (|-) keeps newlines", () => {
+  const raw = "---\nnotes: |-\n  line one\n  line two\n---\nbody\n";
+  const { data } = parseFrontmatter(raw, "<mem>");
+  assert.equal(data.notes, "line one\nline two");
+});
+
+test("frontmatter: folded scalar as a bare sequence item (- >-)", () => {
+  const raw = [
+    "---",
+    "covers:",
+    "  - >-",
+    "    memory: Proactively invoke available skills for the task",
+    "    (frontend-excellence, frontend-design)",
+    "---",
+    "body",
+    "",
+  ].join("\n");
+  const { data } = parseFrontmatter(raw, "<mem>");
+  assert.deepEqual(data.covers, [
+    "memory: Proactively invoke available skills for the task (frontend-excellence, frontend-design)",
+  ]);
+});
+
+test("frontmatter: explicit indentation indicator (>2) is recognised", () => {
+  const raw = "---\nfocus: >2\n  wrapped value\n---\nbody\n";
+  const { data } = parseFrontmatter(raw, "<mem>");
+  assert.equal(data.focus, "wrapped value");
+});
+
+test("frontmatter: bare | and > headers still parse (no regression)", () => {
+  const literal = parseFrontmatter("---\nnote: |\n  a\n  b\n---\nbody\n", "<mem>").data;
+  assert.equal(literal.note, "a\nb");
+  const folded = parseFrontmatter("---\nnote: >\n  a\n  b\n---\nbody\n", "<mem>").data;
+  assert.equal(folded.note, "a b");
+});


### PR DESCRIPTION
## Summary
- The line-based frontmatter parser ([scripts/lib/frontmatter.mjs](scripts/lib/frontmatter.mjs)) matched only the bare `|` and `>` block-scalar headers. A header carrying a chomping indicator (`>-`, `|-`, `>+`, `|+`) or an explicit indentation indicator (`>2`, `|2`) was read as an inline scalar, so the indented continuation line tripped `unexpected indent` and the whole doc was rejected. `index-rebuild` then omitted the doc from its parent `index.md` and `validate` flagged it, even though the frontmatter was valid YAML.
- This bites real data: a serializer (js-yaml via gray-matter, used by the `llm-wiki-memory` leaf writer) folds any scalar longer than its default line width to `>-`, so long `id`/`focus`/`covers` values produced docs that silently vanished from indexes.
- Fix: add a `blockScalarHeader()` recogniser for `|`/`>` with optional chomping and indentation indicators (YAML 1.2 §8.1.1) and route every block-scalar entry point through it, including the previously unhandled bare `- >-` sequence item.

## Test plan
- [x] `npm test` passes (740 pass, 3 platform-skips), including the new `tests/unit/frontmatter-block-scalar.test.mjs`
- [x] New tests cover `>-`, `|-`, folded bare sequence items (`- >-`), explicit indent (`>2`), and a no-regression check on bare `|` / `>`
- [x] Verified against the exact frontmatter from the field report: `id`/`focus`/`covers` now parse instead of throwing `unexpected indent`

## Follow-up
- Companion writer fix in `llm-wiki-memory` (disable js-yaml line folding) so newly written docs stay single-line. The parser fix alone stops the data loss; doing both is belt-and-suspenders.
- Existing already-folded docs in installed wikis need a one-time rewrite (re-save through the fixed writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)