### PR TITLE
feat(indices): descriptive index focuses + tag union (navigable trees)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Deterministic index focuses (navigable trees without an AI pass).** `rebuildIndex` no longer writes the opaque `focus: "subtree under <path>"` placeholder. When an index has no AUTHORED focus (or carries a stale "subtree under" placeholder), it now derives a descriptive focus by summarising its aggregated child entries (leaf focuses / sub-index focuses), and sets a `tags` union from its descendants. Because rebuild runs deepest-first, child topics bubble up the tree, so reading a parent index tells you what's actually inside instead of nothing. Authored focuses/tags are preserved (placeholder detection only refreshes generated ones). This makes a deterministically-built wiki (e.g. an automated memory store) browsable by an LLM without running the AI build/rebuild draft path, which remains available for richer prose.
 - **CLI progress breadcrumbs (Phase X.9).** Long-running operations (build / rebuild / fix / join) now stream a per-phase breadcrumb to stderr as each orchestrator phase fires:
   - `[build-20260424-212011-abc123 3] ingest: read 596 source file(s), 589 leaves`
   - `[build-... 7] operator-convergence: 156 operator(s) applied across 23 iteration(s); ...`

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -525,7 +525,14 @@ function extractAuthoredBlock(body) {
 // authored focus that merely starts with those words (e.g. "subtree under water")
 // is never mistaken for a placeholder and clobbered on rebuild.
 function isPlaceholderFocus(focus, id) {
-  return typeof focus === "string" && focus.trim() === `subtree under ${id}`;
+  if (typeof focus !== "string") return false;
+  const f = focus.trim();
+  // Match the placeholder for the current path-id AND for the legacy basename-id
+  // form: deep indices used to be id'd by basename (e.g. "v1" before the path-id
+  // change made it "api/v1"), so a placeholder written as "subtree under v1" must
+  // still be recognised and refreshed rather than bubbled up as opaque text.
+  const base = String(id).split("/").pop();
+  return f === `subtree under ${id}` || f === `subtree under ${base}`;
 }
 
 // Summarise a directory from its aggregated child entries so the index focus

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -183,9 +183,9 @@ export function rebuildIndex(
   if (isRoot) data.depth_role = "category";
   data.depth = depth;
 
-  if (!data.focus) {
-    data.focus = `subtree under ${data.id}`;
-  }
+  // `focus` (and a derived `tags` union) are computed AFTER the entries are
+  // aggregated below, so the index can summarise its subtree instead of an
+  // opaque "subtree under <path>" placeholder. An authored focus is preserved.
 
   if (!data.parents) {
     if (isRoot) {
@@ -233,6 +233,20 @@ export function rebuildIndex(
     entries.push(record);
   }
   data.entries = entries;
+
+  // Derived focus + tags: make the index self-describing for navigation. When no
+  // focus is authored (or it is a stale "subtree under <path>" placeholder),
+  // summarise the subtree from the aggregated child entries; also union the
+  // descendants' tags when none are authored. rebuildAllIndices / ensureIndexes
+  // run deepest-first, so a child's index focus is already aggregated when its
+  // parent reads it here -> leaf topics bubble up the tree.
+  if (!data.focus || isPlaceholderFocus(data.focus)) {
+    data.focus = deriveIndexFocus(data.id, entries);
+  }
+  if (!Array.isArray(data.tags) || data.tags.length === 0) {
+    const derivedTags = deriveIndexTags(entries);
+    if (derivedTags.length > 0) data.tags = derivedTags;
+  }
 
   // Semantic-routing substrate: `activation_defaults` is NOT
   // auto-aggregated anymore. Claude decides descent from `focus`
@@ -498,6 +512,46 @@ function extractAuthoredBlock(body) {
   const end = body.indexOf(AUTHORED_END);
   if (start === -1 || end === -1 || end <= start) return null;
   return body.slice(start + AUTHORED_BEGIN.length, end).trim();
+}
+
+const PLACEHOLDER_FOCUS_RE = /^subtree under /;
+// A focus the deterministic rebuild generated (vs. an authored one). Detected so
+// a stale placeholder from an older build is refreshed rather than preserved.
+function isPlaceholderFocus(focus) {
+  return typeof focus === "string" && PLACEHOLDER_FOCUS_RE.test(focus.trim());
+}
+
+// Summarise a directory from its aggregated child entries so the index focus
+// describes the subtree (e.g. "landing: backtest cards badges; ocr stat numbers")
+// instead of an opaque "subtree under <path>". Deterministic + length-bounded.
+function deriveIndexFocus(id, entries) {
+  const label = String(id).split("/").pop() || String(id);
+  const topics = [];
+  for (const e of entries || []) {
+    const f = String(e.focus || e.id || "").replace(/\s+/g, " ").trim();
+    if (!f || isPlaceholderFocus(f)) continue;
+    topics.push(f);
+    if (topics.length >= 6) break;
+  }
+  if (topics.length === 0) return `${label}: (no described entries yet)`;
+  const summary = `${label}: ${topics.join("; ")}`;
+  return summary.length > 240 ? `${summary.slice(0, 237)}...` : summary;
+}
+
+// Union of descendant entry tags (entries carry each leaf's / sub-index's tags,
+// so this propagates bottom-up). Tags may be arrays or comma-strings. Sorted +
+// capped for deterministic output.
+function deriveIndexTags(entries) {
+  const seen = new Set();
+  for (const e of entries || []) {
+    const t = e.tags;
+    const arr = Array.isArray(t) ? t : typeof t === "string" ? t.split(",") : [];
+    for (const raw of arr) {
+      const v = String(raw).trim().toLowerCase();
+      if (v) seen.add(v);
+    }
+  }
+  return [...seen].sort().slice(0, 20);
 }
 
 function titleize(id) {

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -243,13 +243,16 @@ export function rebuildIndex(
   if (!data.focus || isPlaceholderFocus(data.focus, data.id)) {
     data.focus = deriveIndexFocus(data.id, entries);
   }
-  // Only derive tags when none are authored, in ANY valid YAML shape: a non-empty
-  // array OR a non-empty string ("foo" / "foo, bar"). Otherwise authored string
-  // tags would be silently replaced by the derived union.
-  const hasAuthoredTags =
-    (Array.isArray(data.tags) && data.tags.length > 0) ||
-    (typeof data.tags === "string" && data.tags.trim() !== "");
-  if (!hasAuthoredTags) {
+  // Normalise authored string tags ("foo" / "foo, bar") into an array: the schema
+  // (guide/basics/schema.md) types tags as string[], so downstream Array.isArray
+  // routing would otherwise ignore a string value entirely.
+  if (typeof data.tags === "string") {
+    data.tags = data.tags.split(",").map((t) => t.trim()).filter(Boolean);
+  }
+  // Derive a descendant-tag union ONLY when tags is absent. The presence of the
+  // key (even an empty `tags: []`) is treated as authored, so an author can
+  // deliberately opt a navigation index out of tags.
+  if (data.tags === undefined) {
     const derivedTags = deriveIndexTags(entries);
     if (derivedTags.length > 0) data.tags = derivedTags;
   }
@@ -389,7 +392,10 @@ function collectDirs(dirPath, wikiRoot, acc, cache) {
 
 function depthOf(dirPath, wikiRoot) {
   if (dirPath === wikiRoot) return 0;
-  return relative(wikiRoot, dirPath).split("/").filter(Boolean).length;
+  // Split on BOTH separators: node's relative() yields "\\" on Windows, and the
+  // deepest-first rebuild order (which the focus/tag bubble-up relies on) would
+  // otherwise miscompute depth there and rebuild parents before children.
+  return relative(wikiRoot, dirPath).split(/[\\/]/).filter(Boolean).length;
 }
 
 function computeDepth(dirPath, wikiRoot) {

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -240,10 +240,16 @@ export function rebuildIndex(
   // descendants' tags when none are authored. rebuildAllIndices runs deepest-first
   // (and incremental callers should rebuild bottom-up), so a child's index focus
   // is already aggregated when its parent reads it here -> leaf topics bubble up.
-  if (!data.focus || isPlaceholderFocus(data.focus)) {
+  if (!data.focus || isPlaceholderFocus(data.focus, data.id)) {
     data.focus = deriveIndexFocus(data.id, entries);
   }
-  if (!Array.isArray(data.tags) || data.tags.length === 0) {
+  // Only derive tags when none are authored, in ANY valid YAML shape: a non-empty
+  // array OR a non-empty string ("foo" / "foo, bar"). Otherwise authored string
+  // tags would be silently replaced by the derived union.
+  const hasAuthoredTags =
+    (Array.isArray(data.tags) && data.tags.length > 0) ||
+    (typeof data.tags === "string" && data.tags.trim() !== "");
+  if (!hasAuthoredTags) {
     const derivedTags = deriveIndexTags(entries);
     if (derivedTags.length > 0) data.tags = derivedTags;
   }
@@ -514,11 +520,12 @@ function extractAuthoredBlock(body) {
   return body.slice(start + AUTHORED_BEGIN.length, end).trim();
 }
 
-const PLACEHOLDER_FOCUS_RE = /^subtree under /;
-// A focus the deterministic rebuild generated (vs. an authored one). Detected so
-// a stale placeholder from an older build is refreshed rather than preserved.
-function isPlaceholderFocus(focus) {
-  return typeof focus === "string" && PLACEHOLDER_FOCUS_RE.test(focus.trim());
+// True only for the EXACT legacy placeholder this skill generated for `id`
+// ("subtree under <id>"). Matching exactly (not a prefix) means a genuinely
+// authored focus that merely starts with those words (e.g. "subtree under water")
+// is never mistaken for a placeholder and clobbered on rebuild.
+function isPlaceholderFocus(focus, id) {
+  return typeof focus === "string" && focus.trim() === `subtree under ${id}`;
 }
 
 // Summarise a directory from its aggregated child entries so the index focus
@@ -529,7 +536,7 @@ function deriveIndexFocus(id, entries) {
   const topics = [];
   for (const e of entries || []) {
     const f = String(e.focus || e.id || "").replace(/\s+/g, " ").trim();
-    if (!f || isPlaceholderFocus(f)) continue;
+    if (!f || isPlaceholderFocus(f, e.id)) continue;
     topics.push(f);
     if (topics.length >= 6) break;
   }

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -237,9 +237,9 @@ export function rebuildIndex(
   // Derived focus + tags: make the index self-describing for navigation. When no
   // focus is authored (or it is a stale "subtree under <path>" placeholder),
   // summarise the subtree from the aggregated child entries; also union the
-  // descendants' tags when none are authored. rebuildAllIndices / ensureIndexes
-  // run deepest-first, so a child's index focus is already aggregated when its
-  // parent reads it here -> leaf topics bubble up the tree.
+  // descendants' tags when none are authored. rebuildAllIndices runs deepest-first
+  // (and incremental callers should rebuild bottom-up), so a child's index focus
+  // is already aggregated when its parent reads it here -> leaf topics bubble up.
   if (!data.focus || isPlaceholderFocus(data.focus)) {
     data.focus = deriveIndexFocus(data.id, entries);
   }

--- a/tests/unit/index-activation-aggregation.test.mjs
+++ b/tests/unit/index-activation-aggregation.test.mjs
@@ -158,6 +158,32 @@ test("rebuildIndex: derives a descriptive focus + tag union from children, bubbl
   }
 });
 
+test("rebuildIndex: refreshes a legacy basename placeholder after the id becomes a path", () => {
+  const wiki = tmp();
+  try {
+    mkdirSync(join(wiki, "api", "v1"), { recursive: true });
+    writeFileSync(join(wiki, "index.md"), "---\nid: wiki\ntype: index\ndepth_role: category\nparents: []\ngenerator: skill-llm-wiki/v1\n---\n");
+    writeFileSync(join(wiki, "api", "index.md"), "---\nid: api\ntype: index\ndepth_role: subcategory\nparents:\n  - ../index.md\ngenerator: skill-llm-wiki/v1\n---\n");
+    // Legacy: this deep index was created with a BASENAME id ("v1") and the matching
+    // placeholder; the id now re-derives to the path "api/v1".
+    writeFileSync(
+      join(wiki, "api", "v1", "index.md"),
+      "---\nid: v1\ntype: index\ndepth_role: subcategory\nfocus: subtree under v1\nparents:\n  - ../index.md\ngenerator: skill-llm-wiki/v1\n---\n",
+    );
+    writeFileSync(
+      join(wiki, "api", "v1", "leaf.md"),
+      "---\nid: leaf\ntype: primary\ndepth_role: leaf\nfocus: handles v1 pagination cursors\nparents:\n  - index.md\n---\n\n# Leaf\n",
+    );
+    rebuildAllIndices(wiki);
+    const v1 = parseFrontmatter(readFileSync(join(wiki, "api", "v1", "index.md"), "utf8")).data;
+    assert.equal(v1.id, "api/v1", "id re-derived to the path");
+    assert.ok(!/^subtree under /.test(v1.focus), `legacy basename placeholder refreshed, not preserved: ${v1.focus}`);
+    assert.match(v1.focus, /pagination/, "focus summarises the leaf");
+  } finally {
+    rmSync(wiki, { recursive: true, force: true });
+  }
+});
+
 test("rebuildIndex: authored source index shared_covers and activation_defaults are forwarded", () => {
   const wiki = tmp();
   try {

--- a/tests/unit/index-activation-aggregation.test.mjs
+++ b/tests/unit/index-activation-aggregation.test.mjs
@@ -106,6 +106,56 @@ test("rebuildIndex: parent entries[] carries leaf id/type/focus/tags but NOT act
   }
 });
 
+test("rebuildIndex: derives a descriptive focus + tag union from children, bubbling up", () => {
+  const wiki = tmp();
+  try {
+    mkdirSync(join(wiki, "cat"), { recursive: true });
+    // root + cat indices start as stale "subtree under" placeholders.
+    writeFileSync(
+      join(wiki, "index.md"),
+      "---\nid: wiki\ntype: index\ndepth_role: category\nfocus: subtree under wiki\nparents: []\ngenerator: skill-llm-wiki/v1\n---\n",
+    );
+    writeFileSync(
+      join(wiki, "cat", "index.md"),
+      "---\nid: cat\ntype: index\ndepth_role: subcategory\nfocus: subtree under cat\nparents:\n  - ../index.md\ngenerator: skill-llm-wiki/v1\n---\n",
+    );
+    writeFileSync(
+      join(wiki, "cat", "leaf-cards.md"),
+      [
+        "---",
+        "id: leaf-cards",
+        "type: primary",
+        "depth_role: leaf",
+        "focus: backtest cards badges must read as data-driven",
+        "parents:",
+        "  - index.md",
+        "tags:",
+        "  - cards",
+        "  - badges",
+        "---",
+        "",
+        "# Backtest cards",
+      ].join("\n"),
+    );
+    rebuildAllIndices(wiki);
+
+    const cat = parseFrontmatter(readFileSync(join(wiki, "cat", "index.md"), "utf8")).data;
+    assert.ok(!/^subtree under /.test(cat.focus), `cat focus still a placeholder: ${cat.focus}`);
+    assert.match(cat.focus, /backtest cards/, `cat focus should summarise its leaf: ${cat.focus}`);
+    assert.ok(
+      Array.isArray(cat.tags) && cat.tags.includes("cards"),
+      `cat tag-union should include 'cards': ${JSON.stringify(cat.tags)}`,
+    );
+
+    // Bubble-up: the root focus aggregates the cat subtree, so 'cards' is reachable from the top.
+    const root = parseFrontmatter(readFileSync(join(wiki, "index.md"), "utf8")).data;
+    assert.ok(!/^subtree under /.test(root.focus), `root focus still a placeholder: ${root.focus}`);
+    assert.match(root.focus, /cards/, `root focus should bubble up the leaf topic: ${root.focus}`);
+  } finally {
+    rmSync(wiki, { recursive: true, force: true });
+  }
+});
+
 test("rebuildIndex: authored source index shared_covers and activation_defaults are forwarded", () => {
   const wiki = tmp();
   try {

--- a/tests/unit/index-activation-aggregation.test.mjs
+++ b/tests/unit/index-activation-aggregation.test.mjs
@@ -184,6 +184,50 @@ test("rebuildIndex: refreshes a legacy basename placeholder after the id becomes
   }
 });
 
+test("rebuildIndex: an authored empty tags list (tags: []) is a preserved opt-out", () => {
+  const wiki = tmp();
+  try {
+    mkdirSync(wiki, { recursive: true });
+    // The index authored `tags: []` to deliberately opt out of routing tags; the
+    // leaf carries tags that would otherwise bubble up into the derived union.
+    writeFileSync(
+      join(wiki, "index.md"),
+      "---\nid: wiki\ntype: index\ndepth_role: category\nfocus: root\nparents: []\ntags: []\ngenerator: skill-llm-wiki/v1\n---\n",
+    );
+    writeFileSync(
+      join(wiki, "leaf.md"),
+      "---\nid: leaf\ntype: primary\ndepth_role: leaf\nfocus: leaf\nparents:\n  - index.md\ntags:\n  - would-bubble\n---\n\n# Leaf\n",
+    );
+    rebuildAllIndices(wiki);
+    const { data } = parseFrontmatter(readFileSync(join(wiki, "index.md"), "utf8"));
+    assert.deepEqual(data.tags, [], "authored empty tags must NOT be replaced by the derived union");
+  } finally {
+    rmSync(wiki, { recursive: true, force: true });
+  }
+});
+
+test("rebuildIndex: authored string tags are normalised to a string[] array", () => {
+  const wiki = tmp();
+  try {
+    mkdirSync(wiki, { recursive: true });
+    // `tags: cards, badges` is valid YAML (a string), but the schema types tags as
+    // string[]; rebuild normalises it so Array.isArray routing sees the values.
+    writeFileSync(
+      join(wiki, "index.md"),
+      "---\nid: wiki\ntype: index\ndepth_role: category\nfocus: root\nparents: []\ntags: cards, badges\ngenerator: skill-llm-wiki/v1\n---\n",
+    );
+    writeFileSync(
+      join(wiki, "leaf.md"),
+      "---\nid: leaf\ntype: primary\ndepth_role: leaf\nfocus: leaf\nparents:\n  - index.md\n---\n\n# Leaf\n",
+    );
+    rebuildAllIndices(wiki);
+    const { data } = parseFrontmatter(readFileSync(join(wiki, "index.md"), "utf8"));
+    assert.deepEqual(data.tags, ["cards", "badges"], "string tags should be split/trimmed into an array");
+  } finally {
+    rmSync(wiki, { recursive: true, force: true });
+  }
+});
+
 test("rebuildIndex: authored source index shared_covers and activation_defaults are forwarded", () => {
   const wiki = tmp();
   try {

--- a/tests/unit/index-activation-aggregation.test.mjs
+++ b/tests/unit/index-activation-aggregation.test.mjs
@@ -110,10 +110,12 @@ test("rebuildIndex: derives a descriptive focus + tag union from children, bubbl
   const wiki = tmp();
   try {
     mkdirSync(join(wiki, "cat"), { recursive: true });
-    // root + cat indices start as stale "subtree under" placeholders.
+    // root has no authored focus (derive path); cat carries a stale "subtree under
+    // cat" placeholder for its own id (refresh path). The root id is the temp dir
+    // name, so we omit its focus rather than guess the exact placeholder string.
     writeFileSync(
       join(wiki, "index.md"),
-      "---\nid: wiki\ntype: index\ndepth_role: category\nfocus: subtree under wiki\nparents: []\ngenerator: skill-llm-wiki/v1\n---\n",
+      "---\nid: wiki\ntype: index\ndepth_role: category\nparents: []\ngenerator: skill-llm-wiki/v1\n---\n",
     );
     writeFileSync(
       join(wiki, "cat", "index.md"),


### PR DESCRIPTION
## Summary

- `rebuildIndex` no longer emits the opaque `focus: "subtree under <path>"` placeholder. With no authored focus (or a stale placeholder), it now derives a descriptive focus by summarising the index's aggregated child entries, and sets a `tags` union from its descendants.
- Rebuild runs deepest-first, so leaf topics **bubble up** the tree: reading a parent index tells you what's inside (e.g. `landing: backtest cards badges; ...`) instead of nothing.
- Authored focuses/tags are preserved — placeholder detection only refreshes generated ones.

## Why

A deterministically-built wiki (e.g. an automated memory store that never runs the AI build/rebuild draft pass) was structurally valid but **not navigable**: every index focus was a content-free placeholder. This makes such trees browsable by an LLM and humans. The AI draft path remains available for richer prose.

## Test plan

- [x] `npm test` — 744 pass (new `index-activation-aggregation` test asserts descriptive focus + tag union + bubble-up; authored-focus preservation still holds)
- [x] `npm run lint` clean; pre-commit gate green
- [x] Existing e2e (orchestrator-build, determinism, nest-convergence) unaffected (validate ignores focus content; determinism holds — aggregation is deterministic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)