### PR TITLE
fix(test): windows-correct path-separator in init envelope check

### DIFF
--- a/tests/unit/init.test.mjs
+++ b/tests/unit/init.test.mjs
@@ -261,7 +261,8 @@ test("`init <topic> --kind dated --json` emits the initialised envelope", () => 
     assert.equal(env.exit, 0);
     assert.equal(env.target, topic);
     assert.equal(env.artifacts.created.length, 1);
-    assert.ok(env.artifacts.created[0].endsWith(".layout/layout.yaml"));
+    // Use path.join so the suffix matches the OS separator (Windows uses `\`).
+    assert.ok(env.artifacts.created[0].endsWith(join(".layout", "layout.yaml")));
     const hint = env.diagnostics.find((d) => d.code === "NEXT-01");
     assert.ok(hint);
     assert.match(hint.message, /skill-llm-wiki build/);


### PR DESCRIPTION
The only Windows-only failure in the v1.4.1 main CI run was a hardcoded
forward-slash in an `endsWith` assertion:

> tests/unit/init.test.mjs:264
> `env.artifacts.created[0].endsWith(\".layout/layout.yaml\")`

On Windows, `init` reports the created path as `…\\.layout\\layout.yaml`, so the
assertion fails. All other 750 tests pass on both Ubuntu and Windows.

Switching the suffix to `join(\".layout\", \"layout.yaml\")` makes it use the
platform separator. Test-only fix; no source/behaviour change.

Failing job: https://github.com/ctxr-dev/skill-llm-wiki/actions/runs/26561698567/job/78246046269
Local: 748 pass / 0 fail (POSIX).