### PR TITLE
fix(indices): URL-encode index.md navigation link destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- URL-encode auto-generated `index.md` navigation link destinations so a child folder or leaf whose name contains a space (or other special character) navigates correctly in Obsidian and standard markdown. The human-readable label keeps the raw relative path; only the link destination is percent-encoded (a no-op for ordinary slugified names).
+
 ## [1.4.3] - 2026-05-30
 
 ### Changed

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -489,7 +489,14 @@ function renderBody(data, existing, sourceAuthoredOrientation) {
     lines.push("|------|------|-------|");
     for (const e of data.entries) {
       const typeTag = e.type === "index" ? "📁 index" : e.type === "overlay" ? "🔗 overlay" : "📄 primary";
-      lines.push(`| [${e.file}](${e.file}) | ${typeTag} | ${e.focus || ""} |`);
+      // URL-encode the link DESTINATION so a path segment with a space (or
+      // other special char) still navigates in Obsidian / standard markdown.
+      // Split on BOTH separators (node's relative() yields "\\" on Windows) and
+      // join with "/" so the destination is a valid forward-slash URL path; the
+      // human-readable label keeps the raw relative path. encodeURIComponent is
+      // a no-op for ordinary slugified segments, so normal links are unchanged.
+      const dest = e.file.split(/[\\/]/).map(encodeURIComponent).join("/");
+      lines.push(`| [${e.file}](${dest}) | ${typeTag} | ${e.focus || ""} |`);
     }
     lines.push("");
   } else {

--- a/scripts/lib/indices.mjs
+++ b/scripts/lib/indices.mjs
@@ -465,6 +465,18 @@ function orderKeys(data, isRoot) {
   return out;
 }
 
+// Percent-encode ONE path segment for a markdown link destination.
+// encodeURIComponent leaves `! ' ( ) *` unescaped, but markdown link
+// destinations `[label](dest)` break on an unescaped `(` or `)` (the paren
+// terminates the destination), so escape those too (RFC3986-style). A no-op
+// for ordinary slugified segments (kebab-case, dots).
+function encodeLinkSegment(seg) {
+  return encodeURIComponent(seg).replace(
+    /[!'()*]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+}
+
 function renderBody(data, existing, sourceAuthoredOrientation) {
   const lines = [];
   lines.push("");
@@ -489,13 +501,13 @@ function renderBody(data, existing, sourceAuthoredOrientation) {
     lines.push("|------|------|-------|");
     for (const e of data.entries) {
       const typeTag = e.type === "index" ? "📁 index" : e.type === "overlay" ? "🔗 overlay" : "📄 primary";
-      // URL-encode the link DESTINATION so a path segment with a space (or
-      // other special char) still navigates in Obsidian / standard markdown.
-      // Split on BOTH separators (node's relative() yields "\\" on Windows) and
-      // join with "/" so the destination is a valid forward-slash URL path; the
-      // human-readable label keeps the raw relative path. encodeURIComponent is
-      // a no-op for ordinary slugified segments, so normal links are unchanged.
-      const dest = e.file.split(/[\\/]/).map(encodeURIComponent).join("/");
+      // URL-encode the link DESTINATION per path segment so a name with a
+      // space, parens, or other special char still navigates in Obsidian /
+      // standard markdown. Split on BOTH separators (node's relative() yields
+      // "\\" on Windows) and join with "/" so the destination is a valid
+      // forward-slash URL path; the human-readable label keeps the raw relative
+      // path. Encoding is a no-op for ordinary slugified segments.
+      const dest = e.file.split(/[\\/]/).map(encodeLinkSegment).join("/");
       lines.push(`| [${e.file}](${dest}) | ${typeTag} | ${e.focus || ""} |`);
     }
     lines.push("");

--- a/tests/unit/index-link-url-encode.test.mjs
+++ b/tests/unit/index-link-url-encode.test.mjs
@@ -1,0 +1,66 @@
+// index-link-url-encode.test.mjs — regression guard for navigable links.
+//
+// rebuildIndex emits the auto-generated navigation as a markdown table of
+// `[label](destination)` links. The destination MUST be URL-encoded: a child
+// folder or leaf whose name contains a space (or other special char) otherwise
+// produces `[Foo Bar](Foo Bar/index.md)`, which Obsidian and standard markdown
+// cannot follow (the space terminates the link destination). The label stays
+// human-readable; only the destination is encoded.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { rebuildIndex } from "../../scripts/lib/indices.mjs";
+import { withTmp } from "../helpers/tmp.mjs";
+
+function leaf(id, focus) {
+  return `---\nid: ${id}\ntype: primary\ndepth_role: leaf\nfocus: ${focus}\nparents:\n  - index.md\n---\n\n# ${focus}\n`;
+}
+function subIndex(id, focus) {
+  return `---\nid: ${id}\ntype: index\ndepth_role: subcategory\nfocus: ${focus}\nparents:\n  - ../index.md\n---\n`;
+}
+
+// Pull every link destination out of the rendered index body.
+function destinations(body) {
+  return [...body.matchAll(/\]\(([^)]*)\)/g)].map((m) => m[1]);
+}
+
+test("rebuildIndex URL-encodes link destinations for names with spaces", async () => {
+  await withTmp("idx-link-enc", async (wiki) => {
+    // A leaf and a child subdir, each with a space in the name.
+    writeFileSync(join(wiki, "my note.md"), leaf("my-note", "spaced leaf"));
+    mkdirSync(join(wiki, "foo bar"), { recursive: true });
+    writeFileSync(join(wiki, "foo bar", "index.md"), subIndex("foo-bar", "spaced folder"));
+    // A normal slugified leaf must be left untouched (encode is a no-op).
+    writeFileSync(join(wiki, "alpha-note.md"), leaf("alpha-note", "normal leaf"));
+
+    rebuildIndex(wiki, wiki);
+    const body = readFileSync(join(wiki, "index.md"), "utf8");
+    const dests = destinations(body);
+
+    // The spaced names are encoded in the destination...
+    assert.ok(dests.includes("my%20note.md"), `leaf dest encoded; got ${JSON.stringify(dests)}`);
+    assert.ok(dests.includes("foo%20bar/index.md"), `folder dest encoded; got ${JSON.stringify(dests)}`);
+    // ...and the normal name is unchanged (no spurious encoding).
+    assert.ok(dests.includes("alpha-note.md"), `normal dest unchanged; got ${JSON.stringify(dests)}`);
+
+    // No destination may contain a raw space (the bug).
+    for (const d of dests) {
+      assert.ok(!d.includes(" "), `destination has a raw space: ${JSON.stringify(d)}`);
+    }
+
+    // Every encoded destination round-trips to a real on-disk relative path.
+    for (const d of dests) {
+      const decoded = d.split("/").map(decodeURIComponent).join("/");
+      assert.ok(
+        readFileSync(join(wiki, decoded), "utf8").length >= 0,
+        `decoded destination ${decoded} resolves to a file`,
+      );
+    }
+
+    // The human-readable label keeps the raw (decoded) path.
+    assert.match(body, /\[foo bar\/index\.md\]\(foo%20bar\/index\.md\)/);
+    assert.match(body, /\[my note\.md\]\(my%20note\.md\)/);
+  });
+});

--- a/tests/unit/index-link-url-encode.test.mjs
+++ b/tests/unit/index-link-url-encode.test.mjs
@@ -59,8 +59,12 @@ test("rebuildIndex URL-encodes link destinations for names with spaces", async (
       );
     }
 
-    // The human-readable label keeps the raw (decoded) path.
-    assert.match(body, /\[foo bar\/index\.md\]\(foo%20bar\/index\.md\)/);
-    assert.match(body, /\[my note\.md\]\(my%20note\.md\)/);
+    // The human-readable label keeps the raw (decoded) path. Normalise path
+    // separators first: node's relative() yields "\\" on Windows, so the label
+    // (raw relative path) varies by platform while the encoded destination is
+    // always forward-slash.
+    const norm = body.replace(/\\/g, "/");
+    assert.match(norm, /\[foo bar\/index\.md\]\(foo%20bar\/index\.md\)/);
+    assert.match(norm, /\[my note\.md\]\(my%20note\.md\)/);
   });
 });

--- a/tests/unit/index-link-url-encode.test.mjs
+++ b/tests/unit/index-link-url-encode.test.mjs
@@ -32,6 +32,9 @@ test("rebuildIndex URL-encodes link destinations for names with spaces", async (
     writeFileSync(join(wiki, "my note.md"), leaf("my-note", "spaced leaf"));
     mkdirSync(join(wiki, "foo bar"), { recursive: true });
     writeFileSync(join(wiki, "foo bar", "index.md"), subIndex("foo-bar", "spaced folder"));
+    // A name with parentheses: encodeURIComponent leaves `(` `)` raw, but an
+    // unescaped `)` terminates a markdown link destination, so it must encode.
+    writeFileSync(join(wiki, "note (draft).md"), leaf("note-draft", "paren leaf"));
     // A normal slugified leaf must be left untouched (encode is a no-op).
     writeFileSync(join(wiki, "alpha-note.md"), leaf("alpha-note", "normal leaf"));
 
@@ -42,12 +45,15 @@ test("rebuildIndex URL-encodes link destinations for names with spaces", async (
     // The spaced names are encoded in the destination...
     assert.ok(dests.includes("my%20note.md"), `leaf dest encoded; got ${JSON.stringify(dests)}`);
     assert.ok(dests.includes("foo%20bar/index.md"), `folder dest encoded; got ${JSON.stringify(dests)}`);
+    // ...parentheses are percent-encoded (%28/%29), not left raw...
+    assert.ok(dests.includes("note%20%28draft%29.md"), `paren dest encoded; got ${JSON.stringify(dests)}`);
     // ...and the normal name is unchanged (no spurious encoding).
     assert.ok(dests.includes("alpha-note.md"), `normal dest unchanged; got ${JSON.stringify(dests)}`);
 
-    // No destination may contain a raw space (the bug).
+    // No destination may contain a char that breaks a markdown link
+    // destination: a raw space, or an unescaped paren.
     for (const d of dests) {
-      assert.ok(!d.includes(" "), `destination has a raw space: ${JSON.stringify(d)}`);
+      assert.ok(!/[ ()]/.test(d), `destination has an unencoded space/paren: ${JSON.stringify(d)}`);
     }
 
     // Every encoded destination round-trips to a real on-disk relative path.


### PR DESCRIPTION
## Problem

Auto-generated `index.md` navigation builds markdown links with the destination interpolated raw (`scripts/lib/indices.mjs`, `renderBody`):

`lines.push(\`| [\${e.file}](\${e.file}) | ... |\`)`

So a child folder or leaf whose name contains a space produces `[Foo Bar](Foo Bar/index.md)`, which **Obsidian and standard markdown cannot follow** (the space terminates the link destination, so clicking the entry does not navigate). Reported in the field for a folder name with a space.

## Fix

Encode the link **destination** per path segment, splitting on both separators and joining with `/` so the result is a valid forward-slash URL path (correct on the Windows CI job too). The human-readable **label** keeps the raw relative path. `encodeURIComponent` is a no-op for ordinary slugified segments (kebab-case, dots), so normal links are byte-identical; only names with spaces / parens / `#` / etc. change.

## Tests

New `tests/unit/index-link-url-encode.test.mjs`: a spaced folder + spaced leaf produce percent-encoded, round-tripping destinations; a normal name is untouched; no destination carries a raw space. Fails on the pre-fix renderer, passes after. Full suite: 749 passing / 3 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)