### PR TITLE
fix(frontmatter): skip escaped quotes in findKeyColon (seq scalar mis-parse)

### DIFF
--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -355,6 +355,15 @@ function findKeyColon(text) {
   let inDouble = false;
   for (let i = 0; i < text.length; i++) {
     const c = text[i];
+    // Inside a double-quoted scalar a backslash escapes the next character
+    // (`\"`, `\\`). Skip it so an escaped quote does not wrongly close the
+    // string and expose an inner `: ` (e.g. `"... fmt.Errorf(\"a: b\")"`) as a
+    // key separator. Single-quoted YAML has no backslash escapes (only `''`),
+    // so this only applies inside double quotes.
+    if (inDouble && c === "\\") {
+      i += 1;
+      continue;
+    }
     if (c === "'" && !inDouble) inSingle = !inSingle;
     else if (c === '"' && !inSingle) inDouble = !inDouble;
     else if (c === ":" && !inSingle && !inDouble) {

--- a/tests/unit/frontmatter-escaped-quote-seq.test.mjs
+++ b/tests/unit/frontmatter-escaped-quote-seq.test.mjs
@@ -1,0 +1,64 @@
+// frontmatter-escaped-quote-seq.test.mjs — regression for the line-based
+// parser mis-reading a double-quoted sequence scalar that contains an escaped
+// quote (`\"`) followed by an inner `: `.
+//
+// findKeyColon tracked double-quote state but did not skip `\"` escapes, so in
+// a value like `"... fmt.Errorf(\"...: %w\", err) ..."` the escaped quote
+// wrongly closed the string and the inner `: ` was seen as a key separator.
+// parseSeq then treated the scalar item as a `- key: value` map, dropping the
+// string (it came back undefined). On a build round-trip (read-modify-write,
+// e.g. soft-dag-parents) the re-render then emitted corrupt, invalid YAML.
+// These tests pin that such a scalar parses as a string and round-trips.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatter, renderFrontmatter } from "../../scripts/lib/frontmatter.mjs";
+
+const VALUE =
+  'Errors wrapped with `fmt.Errorf("...: %w", err)` for `errors.Is`/`errors.As` chains';
+
+test("seq scalar with an escaped quote and inner colon parses as a string", () => {
+  const raw = [
+    "---",
+    "id: lang-go",
+    "audit_surface:",
+    '  - "Errors wrapped with `fmt.Errorf(\\"...: %w\\", err)` for `errors.Is`/`errors.As` chains"',
+    "---",
+    "body",
+  ].join("\n");
+  const { data } = parseFrontmatter(raw, "lang-go.md");
+  assert.ok(Array.isArray(data.audit_surface), "audit_surface should be a list");
+  assert.equal(data.audit_surface.length, 1);
+  assert.equal(typeof data.audit_surface[0], "string");
+  assert.equal(data.audit_surface[0], VALUE);
+});
+
+test("the escaped-quote scalar round-trips (parse -> render -> parse) unchanged", () => {
+  const raw = [
+    "---",
+    "id: lang-go",
+    "audit_surface:",
+    '  - "Errors wrapped with `fmt.Errorf(\\"...: %w\\", err)` for `errors.Is`/`errors.As` chains"',
+    "---",
+    "the body",
+  ].join("\n");
+  const first = parseFrontmatter(raw, "lang-go.md");
+  const rendered = renderFrontmatter(first.data, first.body);
+  const second = parseFrontmatter(rendered, "lang-go.md");
+  assert.deepEqual(second.data.audit_surface, [VALUE]);
+  // idempotent: a second render equals the first.
+  assert.equal(renderFrontmatter(second.data, second.body), rendered);
+});
+
+test("a map value with an escaped quote and inner colon keeps its key", () => {
+  const raw = [
+    "---",
+    'focus: "Detect fmt.Errorf(\\"...: %w\\") misuse"',
+    "id: x",
+    "---",
+    "b",
+  ].join("\n");
+  const { data } = parseFrontmatter(raw, "x.md");
+  assert.equal(data.id, "x");
+  assert.equal(data.focus, 'Detect fmt.Errorf("...: %w") misuse');
+});


### PR DESCRIPTION
Closes #43.

`findKeyColon` tracked single/double-quote state but did not skip backslash escapes inside a double-quoted scalar. In a value like `"... fmt.Errorf(\"...: %w\", err) ..."` the escaped quote `\"` wrongly flipped the in-double-quote state off, exposing the inner `: ` as a key separator. `parseSeq` then read the sequence item as a `- key: value` map and the string came back `undefined`; on a build read-modify-write round-trip (`soft-dag-parents`) the re-render emitted corrupt, invalid YAML that the lenient line parser round-trips but strict parsers (PyYAML, gray-matter) reject.

**Fix:** inside a double-quoted scalar, a backslash escapes the next character; skip it so `\"` / `\\` do not toggle quote state. Single-quoted YAML has no backslash escapes, so this only applies inside double quotes. The helper is shared by `parseMap` and `parseSeq`, so all call sites are covered.

**Discovered** regenerating skill-code-review's `reviewers.wiki` layout-driven: exactly 1 of 476 leaves (`lang-go`, whose `audit_surface` has an embedded `fmt.Errorf("...: %w")` example) was corrupted. With the fix the rebuilt wiki validates clean under both the JS validator and the Python `validate_layout.py` (476 leaves, 0 findings).

**Tests:** adds `tests/unit/frontmatter-escaped-quote-seq.test.mjs` (the seq scalar parse, round-trip idempotence, and a map value of the same shape). Full suite green (770 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)