### PR TITLE
fix(ingest): do not skip build/dist/target for text sources (silent leaf loss)

### DIFF
--- a/scripts/lib/ingest.mjs
+++ b/scripts/lib/ingest.mjs
@@ -31,22 +31,20 @@ const BASE_SKIP_DIRS = new Set([
   "venv",
 ]);
 
-// Build / tool OUTPUT directories. These hold generated artifacts ONLY in a code
-// repository, so they are skipped only when ingesting code (`includeCode`). For a
-// curated text source a directory named `build/`, `dist/`, or `target/` is
-// hand-authored content (for example a leaf folder sharded by id prefix:
-// `reviewers.src/build/build-cargo.md`). Skipping these unconditionally silently
-// dropped such leaves, so for a text source they are NOT skipped.
+// Build / tool OUTPUT directories with NON-dot names. These hold generated
+// artifacts ONLY in a code repository, so they are skipped only when ingesting code
+// (`includeCode`). For a curated text source a directory named `build/`, `dist/`, or
+// `target/` is hand-authored content (for example a leaf folder sharded by id
+// prefix: `reviewers.src/build/build-cargo.md`), and skipping it unconditionally
+// silently dropped such leaves. Dot-named output dirs (`.next`, `.turbo`, `.cache`,
+// ...) are NOT listed here because `walk` already skips every dot-directory
+// unconditionally, for both text and code ingests.
 const CODE_OUTPUT_SKIP_DIRS = new Set([
   "dist",
   "build",
   "target",
   "out",
   "coverage",
-  ".next",
-  ".nuxt",
-  ".turbo",
-  ".cache",
 ]);
 
 const TEXT_EXTS = new Set([

--- a/scripts/lib/ingest.mjs
+++ b/scripts/lib/ingest.mjs
@@ -18,21 +18,35 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, extname, join, relative, sep } from "node:path";
 import { parseSourceFrontmatter } from "./source-frontmatter.mjs";
 
-const SKIP_DIRS = new Set([
+// Directories that are NEVER hand-authored content: dependency installs, VCS
+// metadata, and Python caches/venvs. Always skipped. (Dot-directories are also
+// skipped unconditionally by `walk`, so the dotted entries here are belt-and-braces.)
+const BASE_SKIP_DIRS = new Set([
   "node_modules",
   ".git",
   ".svn",
   ".hg",
-  "dist",
-  "build",
-  "target",
   "__pycache__",
   ".venv",
   "venv",
+]);
+
+// Build / tool OUTPUT directories. These hold generated artifacts ONLY in a code
+// repository, so they are skipped only when ingesting code (`includeCode`). For a
+// curated text source a directory named `build/`, `dist/`, or `target/` is
+// hand-authored content (for example a leaf folder sharded by id prefix:
+// `reviewers.src/build/build-cargo.md`). Skipping these unconditionally silently
+// dropped such leaves, so for a text source they are NOT skipped.
+const CODE_OUTPUT_SKIP_DIRS = new Set([
+  "dist",
+  "build",
+  "target",
+  "out",
+  "coverage",
   ".next",
+  ".nuxt",
   ".turbo",
   ".cache",
-  "coverage",
 ]);
 
 const TEXT_EXTS = new Set([
@@ -73,7 +87,12 @@ const CODE_EXTS = new Set([
 
 export function ingestSource(sourcePath, options = {}) {
   const { includeCode = false } = options;
-  const files = walk(sourcePath, SKIP_DIRS);
+  // Build-output dirs are skipped only for code ingests; a text source treats them
+  // as content (so an id-prefix shard folder like build/ is not silently dropped).
+  const skipDirs = includeCode
+    ? new Set([...BASE_SKIP_DIRS, ...CODE_OUTPUT_SKIP_DIRS])
+    : BASE_SKIP_DIRS;
+  const files = walk(sourcePath, skipDirs);
   files.sort();
   const leaves = [];
   const indexSources = [];

--- a/tests/unit/ingest-skip-dirs.test.mjs
+++ b/tests/unit/ingest-skip-dirs.test.mjs
@@ -1,0 +1,79 @@
+// ingest-skip-dirs.test.mjs - regression: a curated TEXT source must not have its
+// content silently dropped because a directory is named build/ dist/ target/. Those
+// are build-output names skipped only for CODE ingests. A leaf folder sharded by id
+// prefix (e.g. reviewers.src/build/build-cargo.md) is hand-authored content.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ingestSource } from "../../scripts/lib/ingest.mjs";
+
+function freshDir() {
+  const d = join(
+    tmpdir(),
+    `skill-llm-wiki-ingest-skip-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function leaf(dir, id) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${id}.md`),
+    `---\nid: ${id}\ntype: primary\nfocus: ${id}\n---\n\n# ${id}\n`,
+  );
+}
+
+test("text ingest: leaves under build/ dist/ target/ are NOT dropped", () => {
+  const src = freshDir();
+  try {
+    leaf(src, "top-level");
+    leaf(join(src, "build"), "build-cargo");
+    leaf(join(src, "dist"), "dist-thing");
+    leaf(join(src, "target"), "target-thing");
+    const { leaves } = ingestSource(src);
+    const ids = new Set(leaves.map((l) => l.id));
+    assert.ok(ids.has("build-cargo"), "build/ leaf should be ingested");
+    assert.ok(ids.has("dist-thing"), "dist/ leaf should be ingested");
+    assert.ok(ids.has("target-thing"), "target/ leaf should be ingested");
+    assert.ok(ids.has("top-level"));
+    assert.equal(leaves.length, 4);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+  }
+});
+
+test("text ingest: node_modules and __pycache__ are still skipped", () => {
+  const src = freshDir();
+  try {
+    leaf(src, "real");
+    leaf(join(src, "node_modules"), "dep");
+    leaf(join(src, "__pycache__"), "cached");
+    const { leaves } = ingestSource(src);
+    const ids = new Set(leaves.map((l) => l.id));
+    assert.ok(ids.has("real"));
+    assert.ok(!ids.has("dep"), "node_modules must stay skipped");
+    assert.ok(!ids.has("cached"), "__pycache__ must stay skipped");
+    assert.equal(leaves.length, 1);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+  }
+});
+
+test("code ingest (includeCode): build-output dirs ARE still skipped", () => {
+  const src = freshDir();
+  try {
+    leaf(src, "keep");
+    leaf(join(src, "build"), "generated");
+    // includeCode also pulls in code files, but the .md under build/ must be skipped.
+    const { leaves } = ingestSource(src, { includeCode: true });
+    const ids = new Set(leaves.map((l) => l.id));
+    assert.ok(ids.has("keep"));
+    assert.ok(!ids.has("generated"), "build/ must be skipped for a code ingest");
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #45.

`SKIP_DIRS` unconditionally skipped build-output dir names during ingest, so a curated text source with a directory named `build/` (e.g. an id-prefix shard folder `reviewers.src/build/build-cargo.md`) had those leaves **silently dropped** (463 ingested instead of 479).

Split the skip set: `BASE_SKIP_DIRS` (node_modules, VCS, python caches/venvs) is always skipped; `CODE_OUTPUT_SKIP_DIRS` (dist, build, target, out, coverage, .next, .nuxt, .turbo, .cache) is skipped **only** when `includeCode` is set.

**Tests** (`tests/unit/ingest-skip-dirs.test.mjs`): a text source with leaves under `build/`/`dist/`/`target/` ingests all of them; `node_modules`/`__pycache__` stay skipped; a code ingest still skips `build/`. Full suite green (773 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)